### PR TITLE
feat: add vault selector improvements

### DIFF
--- a/packages/app/src/components/pages/home/VaultQueryCard.tsx
+++ b/packages/app/src/components/pages/home/VaultQueryCard.tsx
@@ -1,24 +1,22 @@
 import Button from '@/components/shared/Button'
 import { InputDepositAmount } from '@/components/shared/InputDepositAmount'
 import { Modal } from '@/components/shared/Modal'
-import VaultSelectButton, {
-  type KongVault,
-} from '@/components/shared/VaultSelectButton'
 import { VaultListItem } from '@/components/shared/VaultListItem'
+import VaultSelectButton, { type KongVault } from '@/components/shared/VaultSelectButton'
 import YearnLoader from '@/components/shared/YearnLoader'
 import { VirtualScrollList } from '@/components/ui/VirtualScrollList'
 import { SupportedChain } from '@/config/supportedChains'
+import { CHAIN_ID_TO_ICON, CHAIN_ID_TO_NAME } from '@/constants/chains'
 import { useAprOracle } from '@/hooks/useAprOracle'
+import { useDiscoverVaultByAddress } from '@/hooks/useDiscoverVaultByAddress'
 import { type VaultData, useGetVaults } from '@/hooks/useGetVaults'
 import { useInput } from '@/hooks/useInput'
 import { usePreloadTokenImages } from '@/hooks/usePreloadTokenImages'
 import { findTokenPrice, useTokenPrices } from '@/hooks/useTokenPrices'
-import { useDiscoverVaultByAddress } from '@/hooks/useDiscoverVaultByAddress'
 import { calculateDelta } from '@yearn-oracle-watch/sdk'
 import React from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Address, isAddress } from 'viem'
-import { CHAIN_ID_TO_NAME } from '@/constants/chains'
 
 // Search utility function
 const searchVaults = (vaults: VaultData[], searchTerm: string) => {
@@ -30,14 +28,21 @@ const searchVaults = (vaults: VaultData[], searchTerm: string) => {
     (vault) =>
       vault.name?.toLowerCase().includes(term) ||
       CHAIN_ID_TO_NAME[Number(vault.chainId)]?.toLowerCase().includes(term) ||
-      vault.address?.toLowerCase().includes(term)
+      vault.address?.toLowerCase().includes(term),
   )
+}
+
+type ChainOption = {
+  id: number | null
+  name: string
+  icon?: string
+  count: number
 }
 
 // Debounce utility function
 const debounce = <T extends (...args: any[]) => void>(
   func: T,
-  delay: number
+  delay: number,
 ): ((...args: Parameters<T>) => void) => {
   let timeoutId: NodeJS.Timeout
   return (...args: Parameters<T>) => {
@@ -54,13 +59,11 @@ const VaultQueryCard: React.FC = () => {
   const [selectedAsset, setSelectedAsset] = React.useState('USD')
   const [selectedVault, setSelectedVault] = React.useState({} as KongVault)
   const [vaultModalOpen, setVaultModalOpen] = React.useState(false)
-  const [deltaValue, setDeltaValue] = React.useState<bigint | undefined>(
-    undefined
-  )
+  const [deltaValue, setDeltaValue] = React.useState<bigint | undefined>(undefined)
   const [searchTerm, setSearchTerm] = React.useState('')
+  const [selectedChainId, setSelectedChainId] = React.useState<number | null>(null)
   const [filteredVaults, setFilteredVaults] = React.useState<VaultData[]>([])
-  const { data: discoveredVaults, isLoading: isDiscovering } =
-    useDiscoverVaultByAddress(searchTerm)
+  const { data: discoveredVaults, isLoading: isDiscovering } = useDiscoverVaultByAddress(searchTerm)
 
   const handleSelectVault = () => {
     setVaultModalOpen(true)
@@ -104,7 +107,7 @@ const VaultQueryCard: React.FC = () => {
         const foundVault = data.find(
           (vault) =>
             vault.address.toLowerCase() === vaultAddress.toLowerCase() &&
-            vault.chainId === Number(chainId)
+            vault.chainId === Number(chainId),
         )
 
         if (foundVault && !selectedVault?.address) {
@@ -122,7 +125,7 @@ const VaultQueryCard: React.FC = () => {
         const filtered = searchVaults(data || [], term)
         setFilteredVaults(filtered)
       }, 150),
-    [data]
+    [data],
   )
 
   // Effect to handle search term changes
@@ -152,12 +155,43 @@ const VaultQueryCard: React.FC = () => {
     })
   }, [filteredVaults, discoveredVaults, searchTerm])
 
+  const chainOptions: ChainOption[] = React.useMemo(() => {
+    const counts = displayVaults.reduce<Record<number, number>>((acc, vault) => {
+      acc[vault.chainId] = (acc[vault.chainId] || 0) + 1
+      return acc
+    }, {})
+
+    const options = Object.entries(counts)
+      .map(([chainId, count]) => {
+        const id = Number(chainId)
+        return {
+          id,
+          name: CHAIN_ID_TO_NAME[id] || `Chain ${id}`,
+          icon: CHAIN_ID_TO_ICON[id],
+          count,
+        }
+      })
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    return [
+      {
+        id: null,
+        name: 'All',
+        count: displayVaults.length,
+      },
+      ...options,
+    ]
+  }, [displayVaults])
+
+  const chainFilteredVaults = React.useMemo(() => {
+    if (!selectedChainId) return displayVaults
+    return displayVaults.filter((vault) => vault.chainId === selectedChainId)
+  }, [displayVaults, selectedChainId])
+
   // Track which items came from on-chain discovery for UI indicators
   const discoveredSet = React.useMemo(() => {
     const set = new Set<string>()
-    ;(discoveredVaults || []).forEach((v) =>
-      set.add(`${v.chainId}-${v.address.toLowerCase()}`)
-    )
+    ;(discoveredVaults || []).forEach((v) => set.add(`${v.chainId}-${v.address.toLowerCase()}`))
     return set
   }, [discoveredVaults])
 
@@ -186,11 +220,7 @@ const VaultQueryCard: React.FC = () => {
   const vaultSymbol = selectedVault?.asset?.symbol || 'yvUSDC'
   const assetPrice =
     pricesData && selectedVault?.asset?.address && selectedVault?.chainId
-      ? findTokenPrice(
-          pricesData,
-          selectedVault.asset.address,
-          selectedVault.chainId
-        )
+      ? findTokenPrice(pricesData, selectedVault.asset.address, selectedVault.chainId)
       : null
 
   const handleQuery = () => {
@@ -207,7 +237,7 @@ const VaultQueryCard: React.FC = () => {
       inputAmount,
       selectedVault.asset?.decimals || 18,
       selectedAsset === 'USD',
-      assetPrice || undefined
+      assetPrice || undefined,
     )
 
     setDeltaValue(delta)
@@ -216,9 +246,7 @@ const VaultQueryCard: React.FC = () => {
   const balance = 0n
 
   // Find the full vault with logos for InputDepositAmount
-  const selectedVaultWithLogos = data?.find(
-    (vault) => vault.address === selectedVault?.address
-  )
+  const selectedVaultWithLogos = data?.find((vault) => vault.address === selectedVault?.address)
 
   if (isLoading) {
     return (
@@ -252,8 +280,9 @@ const VaultQueryCard: React.FC = () => {
               <Modal
                 open={vaultModalOpen}
                 onClose={handleCloseVaultModal}
+                maxWidth="max-w-lg"
                 title={
-                  <div className="flex items-center gap-2 w-full">
+                  <div className="flex w-full flex-col gap-2">
                     <div className="relative flex-1">
                       <input
                         type="text"
@@ -263,19 +292,22 @@ const VaultQueryCard: React.FC = () => {
                         onChange={(e) => handleSearchChange(e.target.value)}
                       />
                     </div>
+                    <ChainSelector
+                      options={chainOptions}
+                      selectedChainId={selectedChainId}
+                      onSelect={setSelectedChainId}
+                    />
                   </div>
                 }
               >
                 <ModalData
-                  data={displayVaults}
+                  data={chainFilteredVaults}
                   searchTerm={searchTerm}
                   isLoading={isLoading}
                   error={error}
                   discoveredSet={discoveredSet}
                   isProbingOnChain={
-                    isAddress(searchTerm) &&
-                    filteredVaults.length === 0 &&
-                    isDiscovering
+                    isAddress(searchTerm) && chainFilteredVaults.length === 0 && isDiscovering
                   }
                   onClose={handleCloseVaultModal}
                   onSelect={(vault) => {
@@ -302,13 +334,9 @@ const VaultQueryCard: React.FC = () => {
                   balance={balance}
                   currentVault={selectedVaultWithLogos}
                   assetPrice={assetPrice}
-                  onCurrencyChange={(newCurrency) =>
-                    setSelectedAsset(newCurrency)
-                  }
+                  onCurrencyChange={(newCurrency) => setSelectedAsset(newCurrency)}
                   onButtonClick={() =>
-                    setSelectedAsset(
-                      selectedAsset === 'USD' ? vaultSymbol : 'USD'
-                    )
+                    setSelectedAsset(selectedAsset === 'USD' ? vaultSymbol : 'USD')
                   }
                 />
               </div>
@@ -336,13 +364,9 @@ const VaultQueryCard: React.FC = () => {
                       isAprOracleLoading ? (
                         <span className="text-[#9E9E9E]">Loading...</span>
                       ) : aprOracleError ? (
-                        <span className="text-[#9E9E9E]">
-                          Error loading APR
-                        </span>
+                        <span className="text-[#9E9E9E]">Error loading APR</span>
                       ) : aprOracleResult?.currentApr ? (
-                        <span className="text-[#1E1E1E]">
-                          {aprOracleResult.currentApr}
-                        </span>
+                        <span className="text-[#1E1E1E]">{aprOracleResult.currentApr}</span>
                       ) : (
                         <span className="text-[#9E9E9E]">Error</span>
                       )
@@ -360,20 +384,14 @@ const VaultQueryCard: React.FC = () => {
                       isAprOracleLoading ? (
                         <span className="text-[#9E9E9E]">Loading...</span>
                       ) : aprOracleError ? (
-                        <span className="text-[#9E9E9E]">
-                          Error loading APR
-                        </span>
+                        <span className="text-[#9E9E9E]">Error loading APR</span>
                       ) : aprOracleResult?.projectedApr ? (
-                        <span className="text-[#1E1E1E]">
-                          {aprOracleResult.projectedApr}
-                        </span>
+                        <span className="text-[#1E1E1E]">{aprOracleResult.projectedApr}</span>
                       ) : (
                         <span className="text-[#9E9E9E]">Error</span>
                       )
                     ) : (
-                      <span className="text-[#9E9E9E]">
-                        Input deposit value
-                      </span>
+                      <span className="text-[#9E9E9E]">Input deposit value</span>
                     )}
                   </div>
                 </div>
@@ -399,9 +417,7 @@ const VaultQueryCard: React.FC = () => {
                         <span className="text-[#9E9E9E]">Error</span>
                       )
                     ) : (
-                      <span className="text-[#9E9E9E]">
-                        Input deposit value
-                      </span>
+                      <span className="text-[#9E9E9E]">Input deposit value</span>
                     )}
                   </div>
                 </div>
@@ -434,7 +450,7 @@ const ModalContainer: React.FC<{
   children: React.ReactNode
   hasTopPadding?: boolean
 }> = ({ children, hasTopPadding = false }) => (
-  <div className={`flex flex-col gap-1 p-4 ${hasTopPadding ? '' : 'pt-0'}`}>
+  <div className={`flex flex-col gap-1 px-4 pb-4 ${hasTopPadding ? 'pt-4' : 'pt-3'}`}>
     {children}
   </div>
 )
@@ -457,6 +473,71 @@ const CloseButton: React.FC<{
   <Button className={marginTop} variant="outlined" onClick={onClick}>
     Close
   </Button>
+)
+
+const ChainSelector: React.FC<{
+  options: ChainOption[]
+  selectedChainId: number | null
+  onSelect: (chainId: number | null) => void
+}> = ({ options, selectedChainId, onSelect }) => (
+  <div className="w-full overflow-x-auto">
+    <div className="inline-flex min-w-max items-center overflow-hidden rounded-[10px] border border-black/10 bg-white">
+      {options.map((option) => {
+        const selected = option.id === selectedChainId
+        const isAllChains = option.id === null
+
+        return (
+          <button
+            key={option.id ?? 'all'}
+            type="button"
+            onClick={() => onSelect(option.id)}
+            title={`${option.name} (${option.count})`}
+            aria-label={`${option.name} (${option.count})`}
+            className={`h-10 border-r border-black/10 flex items-center justify-center transition-colors last:border-r-0 ${
+              isAllChains ? 'gap-1.5 px-3' : 'w-9 px-0'
+            } ${selected ? 'bg-[#F5F5F5]' : 'hover:bg-black/5'}`}
+          >
+            {isAllChains ? (
+              <>
+                <span className="h-5 w-5 overflow-hidden rounded-full bg-black flex items-center justify-center">
+                  <img
+                    src="/images/yearn.svg"
+                    alt=""
+                    className="h-3.5 w-3.5 invert"
+                    referrerPolicy="no-referrer"
+                  />
+                </span>
+                <span className="text-sm font-bold leading-none text-black font-aeonik">
+                  All Chains
+                </span>
+              </>
+            ) : option.icon ? (
+              <span
+                className={`h-5 w-5 rounded-full flex items-center justify-center ${
+                  selected ? 'ring-2 ring-black/15' : ''
+                }`}
+              >
+                <img
+                  src={option.icon}
+                  alt=""
+                  className="h-5 w-5 rounded-full"
+                  referrerPolicy="no-referrer"
+                />
+              </span>
+            ) : (
+              <span
+                className={`h-5 w-5 rounded-full border border-black/10 bg-black/5 flex items-center justify-center text-[10px] font-bold text-black ${
+                  selected ? 'ring-2 ring-black/15' : ''
+                }`}
+              >
+                {option.name.slice(0, 1)}
+              </span>
+            )}
+          </button>
+        )
+      })}
+    </div>
+  </div>
 )
 
 const ModalData: React.FC<ModalDataProps> = ({
@@ -484,9 +565,7 @@ const ModalData: React.FC<ModalDataProps> = ({
     return (
       <ModalContainer>
         <CenteredContent>
-          <div className="text-red-500">
-            Error loading vaults: {error.message}
-          </div>
+          <div className="text-red-500">Error loading vaults: {error.message}</div>
         </CenteredContent>
         <CloseButton onClick={onClose} />
       </ModalContainer>
@@ -506,8 +585,7 @@ const ModalData: React.FC<ModalDataProps> = ({
                 <YearnLoader fixed={false} color="blue" />
               </div>
               <div className="text-gray-500 text-lg text-center">
-                No vaults found in Indexer with matching address, looking
-                directly on chain.
+                No vaults found in Indexer with matching address, looking directly on chain.
               </div>
             </>
           ) : (
@@ -530,7 +608,7 @@ const ModalData: React.FC<ModalDataProps> = ({
       <VirtualScrollList
         items={vaults}
         itemHeight={70} // 70px item height
-        containerHeight={490} // 70px * 7 rows
+        containerHeight={420} // 70px * 6 rows
         className="w-full"
         renderItem={(vault, index, isVisible) => (
           <VaultListItem
@@ -538,9 +616,7 @@ const ModalData: React.FC<ModalDataProps> = ({
             vault={vault}
             searchTerm={searchTerm}
             isVisible={isVisible}
-            discovered={discoveredSet?.has(
-              `${vault.chainId}-${vault.address.toLowerCase()}`
-            )}
+            discovered={discoveredSet?.has(`${vault.chainId}-${vault.address.toLowerCase()}`)}
             onClick={() => onSelect(vault)}
           />
         )}

--- a/packages/app/src/components/pages/home/VaultQueryCard.tsx
+++ b/packages/app/src/components/pages/home/VaultQueryCard.tsx
@@ -463,10 +463,14 @@ const ModalContainer: React.FC<{
 
 const CenteredContent: React.FC<{
   children: React.ReactNode
-  variant?: 'single' | 'stacked'
+  variant?: 'single' | 'stacked' | 'compact'
 }> = ({ children, variant = 'single' }) => (
   <div
-    className={`flex ${variant === 'single' ? 'justify-center items-center' : 'flex-col justify-center items-center'} h-[490px] ${variant === 'stacked' ? 'gap-2' : ''}`}
+    className={`flex ${
+      variant === 'single' ? 'justify-center items-center' : 'flex-col justify-center items-center'
+    } ${variant === 'compact' ? 'min-h-[180px] py-8 gap-2' : 'h-[490px]'} ${
+      variant === 'stacked' ? 'gap-2' : ''
+    }`}
   >
     {children}
   </div>
@@ -588,7 +592,7 @@ const ModalData: React.FC<ModalDataProps> = ({
   if ((searchTerm?.trim() || hasActiveFilters) && vaults.length === 0) {
     return (
       <ModalContainer>
-        <CenteredContent variant="stacked">
+        <CenteredContent variant={hasFilterOnlyEmptyState ? 'compact' : 'stacked'}>
           {hasFilterOnlyEmptyState ? (
             <>
               <div className="text-gray-500 text-lg">No vaults match this filter</div>

--- a/packages/app/src/components/pages/home/VaultQueryCard.tsx
+++ b/packages/app/src/components/pages/home/VaultQueryCard.tsx
@@ -305,10 +305,13 @@ const VaultQueryCard: React.FC = () => {
                   searchTerm={searchTerm}
                   isLoading={isLoading}
                   error={error}
+                  hasActiveFilters={selectedChainId !== null}
+                  unfilteredResultCount={displayVaults.length}
                   discoveredSet={discoveredSet}
                   isProbingOnChain={
                     isAddress(searchTerm) && chainFilteredVaults.length === 0 && isDiscovering
                   }
+                  onClearFilters={() => setSelectedChainId(null)}
                   onClose={handleCloseVaultModal}
                   onSelect={(vault) => {
                     setSelectedVault(vault as KongVault)
@@ -440,7 +443,10 @@ type ModalDataProps = {
   isLoading?: boolean
   error?: Error | null
   isProbingOnChain?: boolean
+  hasActiveFilters?: boolean
+  unfilteredResultCount?: number
   discoveredSet?: Set<string>
+  onClearFilters: () => void
   onClose: () => void
   onSelect: (vault: VaultData) => void
 }
@@ -546,7 +552,10 @@ const ModalData: React.FC<ModalDataProps> = ({
   isLoading,
   error,
   isProbingOnChain,
+  hasActiveFilters = false,
+  unfilteredResultCount = 0,
   discoveredSet,
+  onClearFilters,
   onClose,
   onSelect,
 }) => {
@@ -573,13 +582,24 @@ const ModalData: React.FC<ModalDataProps> = ({
   }
 
   const vaults = Array.isArray(data) && data.length > 0 ? data : []
+  const hasFilterOnlyEmptyState = hasActiveFilters && unfilteredResultCount > 0
 
   // Empty state when no results found after search
-  if (searchTerm?.trim() && vaults.length === 0) {
+  if ((searchTerm?.trim() || hasActiveFilters) && vaults.length === 0) {
     return (
       <ModalContainer>
         <CenteredContent variant="stacked">
-          {isProbingOnChain ? (
+          {hasFilterOnlyEmptyState ? (
+            <>
+              <div className="text-gray-500 text-lg">No vaults match this filter</div>
+              <div className="text-gray-400 text-sm text-center">
+                Remove filters to show {unfilteredResultCount} matching vaults.
+              </div>
+              <Button className="mt-2" variant="outlined" onClick={onClearFilters}>
+                Remove filters
+              </Button>
+            </>
+          ) : isProbingOnChain ? (
             <>
               <div className="mb-2">
                 <YearnLoader fixed={false} color="blue" />

--- a/packages/app/src/components/pages/home/VaultQueryCard.tsx
+++ b/packages/app/src/components/pages/home/VaultQueryCard.tsx
@@ -468,9 +468,7 @@ const CenteredContent: React.FC<{
   <div
     className={`flex ${
       variant === 'single' ? 'justify-center items-center' : 'flex-col justify-center items-center'
-    } ${variant === 'compact' ? 'min-h-[180px] py-8 gap-2' : 'h-[490px]'} ${
-      variant === 'stacked' ? 'gap-2' : ''
-    }`}
+    } h-[420px] ${variant === 'stacked' ? 'gap-2' : ''} ${variant === 'compact' ? 'gap-2' : ''}`}
   >
     {children}
   </div>

--- a/packages/app/src/components/pages/home/VaultQueryCard.tsx
+++ b/packages/app/src/components/pages/home/VaultQueryCard.tsx
@@ -592,7 +592,7 @@ const ModalData: React.FC<ModalDataProps> = ({
   if ((searchTerm?.trim() || hasActiveFilters) && vaults.length === 0) {
     return (
       <ModalContainer>
-        <CenteredContent variant={hasFilterOnlyEmptyState ? 'compact' : 'stacked'}>
+        <CenteredContent variant="compact">
           {hasFilterOnlyEmptyState ? (
             <>
               <div className="text-gray-500 text-lg">No vaults match this filter</div>

--- a/packages/app/src/components/shared/InputDepositAmount.tsx
+++ b/packages/app/src/components/shared/InputDepositAmount.tsx
@@ -150,6 +150,7 @@ export const InputDepositAmount: FC<Props> = ({
           onChange={handleInputChange}
           onFocus={() => setActive(true)}
           onBlur={() => setActive(false)}
+          inputMode="decimal"
           className={cn(
             'self-stretch px-6 rounded-[12px] bg-transparent outline-none text-xl font-normal leading-8 font-mono min-w-0',
             disabled ? 'text-gray-700' : 'text-[#1E1E1E]',

--- a/packages/app/src/components/shared/InputTokenAmount.tsx
+++ b/packages/app/src/components/shared/InputTokenAmount.tsx
@@ -5,6 +5,29 @@ import { exactToSimple, simpleToExact } from '@/utils'
 import { cn } from '@/utils/cn'
 import { ChangeEvent, FC } from 'react'
 
+const formatAmountDisplay = (value: string): string => {
+  if (!value) return ''
+
+  const hasDecimalPoint = value.includes('.')
+  const endsWithDecimal = value.endsWith('.')
+  const [whole = '', fraction = ''] = value.split('.')
+  const sign = whole.startsWith('-') ? '-' : ''
+  const unsignedWhole = sign ? whole.slice(1) : whole
+  const formattedWhole = unsignedWhole.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  const prefix = sign + (unsignedWhole ? formattedWhole : '')
+  const base = unsignedWhole ? prefix : sign ? sign : ''
+
+  if (!hasDecimalPoint) {
+    return base
+  }
+
+  if (endsWithDecimal) {
+    return `${base}.`
+  }
+
+  return `${base}.${fraction}`
+}
+
 interface Props {
   input: ReturnType<typeof useInput>
   className?: string
@@ -43,8 +66,9 @@ export const InputTokenAmount: FC<Props> = ({
   const disabled = _disabled || !account
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = event.target.value.replace(/,/g, '')
     handleChangeInput(event)
-    onInputChange?.(simpleToExact(event.target.value))
+    onInputChange?.(simpleToExact(rawValue === '' ? 0 : rawValue))
   }
 
   return (
@@ -59,10 +83,11 @@ export const InputTokenAmount: FC<Props> = ({
           <input
             disabled={disabled}
             placeholder={placeholder ?? '0.00'}
-            value={formValue}
+            value={formatAmountDisplay(formValue)}
             onChange={handleInputChange}
             onFocus={() => setActive(true)}
             onBlur={() => setActive(false)}
+            inputMode="decimal"
             className={cn(
               'flex-grow bg-transparent outline-none text-lg sm:text-[20px] font-mono min-w-0',
               disabled ? 'text-gray-700' : 'text-gray-900',

--- a/packages/app/src/components/shared/Modal.tsx
+++ b/packages/app/src/components/shared/Modal.tsx
@@ -48,7 +48,7 @@ export const Modal: FC<PropsWithChildren<Props>> = ({
           >
             {/* Header */}
             {hasHeader && (
-              <div className="flex items-center justify-between p-6 border-b border-gray-200">
+              <div className="flex items-center justify-between px-6 pt-6 pb-3 border-b border-gray-200">
                 {typeof title === 'string' ? (
                   <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
                 ) : (

--- a/packages/app/src/components/shared/Navigation.tsx
+++ b/packages/app/src/components/shared/Navigation.tsx
@@ -5,6 +5,8 @@ interface NavigationProps {
   showConnectButton?: boolean
 }
 
+const ORACLE_CONTRACT_ADDRESS = '0x1981AD9F44F2EA9aDd2dC4AD7D075c102C70aF92'
+
 export function Navigation({ showConnectButton = false }: NavigationProps) {
   return (
     <nav className="border-b border-white/5">
@@ -27,16 +29,36 @@ export function Navigation({ showConnectButton = false }: NavigationProps) {
             <div className="hidden sm:flex items-center gap-4">
               <nav className="flex items-center gap-4 mr-6">
                 <a
-                  href="https://yearn.fi/v3"
+                  href="https://yearn.fi/vaults"
+                  target="_blank"
+                  rel="noreferrer"
                   className="text-white/80 text-sm hover:text-white transition-colors"
                 >
                   Vaults
                 </a>
                 <a
                   href="https://docs.yearn.fi/"
+                  target="_blank"
+                  rel="noreferrer"
                   className="text-white/80 text-sm hover:text-white transition-colors"
                 >
                   Docs
+                </a>
+                <a
+                  href="https://github.com/yearn/yearn-oracle-watch"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-white/80 text-sm hover:text-white transition-colors"
+                >
+                  GitHub
+                </a>
+                <a
+                  href={`https://etherscan.io/address/${ORACLE_CONTRACT_ADDRESS}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-white/80 text-sm hover:text-white transition-colors"
+                >
+                  Contract
                 </a>
               </nav>
               {showConnectButton && (

--- a/packages/app/src/components/shared/VaultListItem.tsx
+++ b/packages/app/src/components/shared/VaultListItem.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import { CHAIN_ID_TO_NAME } from '@/constants/chains'
-import { useTokenImage } from '@/hooks/useTokenImage'
+import { CHAIN_ID_TO_ICON, CHAIN_ID_TO_NAME } from '@/constants/chains'
 import { type VaultData } from '@/hooks/useGetVaults'
+import { useTokenImage } from '@/hooks/useTokenImage'
+import React from 'react'
 
 interface VaultListItemProps {
   vault: VaultData
@@ -52,14 +52,30 @@ export const VaultListItem: React.FC<VaultListItemProps> = ({
   }
 
   const chainName = CHAIN_ID_TO_NAME[Number(vault.chainId)]
+  const chainIcon = CHAIN_ID_TO_ICON[Number(vault.chainId)]
 
   // Render image with loading states
   const renderImage = () => {
+    const imageClassName = 'w-10 h-10 min-w-10 min-h-10 max-w-10 max-h-10 rounded-full'
+    const badge = chainIcon ? (
+      <span className="absolute -bottom-0.5 -left-0.5 h-4 w-4 rounded-full border-2 border-gray-100 bg-white shadow-sm">
+        <img
+          className="h-full w-full rounded-full"
+          src={chainIcon}
+          alt=""
+          referrerPolicy="no-referrer"
+        />
+      </span>
+    ) : null
+
     if (!isVisible) {
       // Show placeholder when not visible
       return (
-        <div className="w-8 h-8 min-w-8 min-h-8 max-w-8 max-h-8 bg-gray-200 rounded-full flex items-center justify-center">
-          <div className="w-4 h-4 bg-gray-300 rounded-full" />
+        <div className="relative shrink-0">
+          <div className={`${imageClassName} bg-gray-200 flex items-center justify-center`}>
+            <div className="w-5 h-5 bg-gray-300 rounded-full" />
+          </div>
+          {badge}
         </div>
       )
     }
@@ -67,8 +83,13 @@ export const VaultListItem: React.FC<VaultListItemProps> = ({
     if (imageError) {
       // Show question mark icon on error
       return (
-        <div className="w-8 h-8 min-w-8 min-h-8 max-w-8 max-h-8 bg-gray-200 rounded-full flex items-center justify-center text-gray-500 text-sm">
-          ?
+        <div className="relative shrink-0">
+          <div
+            className={`${imageClassName} bg-gray-200 flex items-center justify-center text-gray-500 text-sm`}
+          >
+            ?
+          </div>
+          {badge}
         </div>
       )
     }
@@ -76,18 +97,24 @@ export const VaultListItem: React.FC<VaultListItemProps> = ({
     if (imageLoading || !imageSrc) {
       // Show subtle loading placeholder
       return (
-        <div className="w-8 h-8 min-w-8 min-h-8 max-w-8 max-h-8 bg-gray-200 rounded-full animate-pulse" />
+        <div className="relative shrink-0">
+          <div className={`${imageClassName} bg-gray-200 animate-pulse`} />
+          {badge}
+        </div>
       )
     }
 
     // Show actual image
     return (
-      <img
-        className="w-8 h-8 min-w-8 min-h-8 max-w-8 max-h-8 relative rounded-full"
-        src={imageSrc}
-        alt={vault.name as string}
-        referrerPolicy="no-referrer"
-      />
+      <div className="relative shrink-0">
+        <img
+          className={imageClassName}
+          src={imageSrc}
+          alt={vault.name as string}
+          referrerPolicy="no-referrer"
+        />
+        {badge}
+      </div>
     )
   }
 
@@ -96,7 +123,7 @@ export const VaultListItem: React.FC<VaultListItemProps> = ({
       className="h-[70px] px-6 py-1 bg-gray-100/50 overflow-hidden rounded-[16px] flex items-center gap-2 cursor-pointer hover:bg-gray-200/50 transition-colors duration-150"
       onClick={onClick}
     >
-      <div className="flex items-center gap-2 px-2 flex-1 min-w-0">
+      <div className="flex items-center gap-4 px-2 flex-1 min-w-0">
         {renderImage()}
         <div className="flex flex-col items-start justify-start truncate">
           <div className="text-[#1E1E1E] text-[16px] font-aeonik font-normal leading-5 truncate">

--- a/packages/app/src/config/katana.ts
+++ b/packages/app/src/config/katana.ts
@@ -1,0 +1,22 @@
+import { defineChain } from 'viem'
+
+export const katana = defineChain({
+  id: 747474,
+  name: 'Katana',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Ether',
+    symbol: 'ETH',
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://rpc.katana.network'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Katana Explorer',
+      url: 'https://explorer.katanarpc.com',
+    },
+  },
+})

--- a/packages/app/src/config/supportedChains.ts
+++ b/packages/app/src/config/supportedChains.ts
@@ -1,8 +1,18 @@
 // !INJECTED
 import { arbitrum, base, gnosis, mainnet, optimism, polygon, sonic } from 'viem/chains'
+import { katana } from './katana'
 
 // !INJECTED
-export const supportedChains = [mainnet, optimism, gnosis, polygon, sonic, base, arbitrum] as const
+export const supportedChains = [
+  mainnet,
+  optimism,
+  gnosis,
+  polygon,
+  sonic,
+  base,
+  arbitrum,
+  katana,
+] as const
 
 export type SupportedChain = (typeof supportedChains)[number]['id']
 

--- a/packages/app/src/config/wagmi.ts
+++ b/packages/app/src/config/wagmi.ts
@@ -9,21 +9,22 @@ import {
 } from '@rainbow-me/rainbowkit/wallets'
 import { Config, http } from 'wagmi'
 import {
+  arbitrum,
+  base,
+  gnosis,
   mainnet,
   optimism,
-  gnosis,
   polygon,
   sonic,
-  base,
-  arbitrum,
 } from 'wagmi/chains'
+import { katana } from './katana'
 
 const name = 'yearn-oracle-watch'
 
 export const config: Config = getDefaultConfig({
   appName: name,
   projectId: import.meta.env?.VITE_WALLETCONNECT_PROJECT_ID ?? 'projectId',
-  chains: [mainnet, optimism, gnosis, polygon, sonic, base, arbitrum],
+  chains: [mainnet, optimism, gnosis, polygon, sonic, base, arbitrum, katana],
   transports: {
     [mainnet.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_1}`),
     [optimism.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_10}`),
@@ -32,6 +33,7 @@ export const config: Config = getDefaultConfig({
     [sonic.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_146}`),
     [base.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_8453}`),
     [arbitrum.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_42161}`),
+    [katana.id]: http(import.meta.env.VITE_RPC_URI_FOR_747474 ?? 'https://rpc.katana.network'),
   },
   wallets: [
     {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ mode }) => {
     VITE_RPC_URI_FOR_146: env.RPC_URI_FOR_146,
     VITE_RPC_URI_FOR_8453: env.RPC_URI_FOR_8453,
     VITE_RPC_URI_FOR_42161: env.RPC_URI_FOR_42161,
+    VITE_RPC_URI_FOR_747474: env.RPC_URI_FOR_747474,
     VITE_WALLETCONNECT_PROJECT_ID: env.WALLETCONNECT_PROJECT_ID,
   }
 
@@ -38,39 +39,34 @@ export default defineConfig(({ mode }) => {
         jsx: 'automatic',
       },
       // Include workspace packages to be pre-bundled
-      include: isDev
-        ? []
-        : ['@yearn-oracle-watch/sdk', '@yearn-oracle-watch/contracts'],
-      exclude: isDev
-        ? ['@yearn-oracle-watch/sdk', '@yearn-oracle-watch/contracts']
-        : [],
+      include: isDev ? [] : ['@yearn-oracle-watch/sdk', '@yearn-oracle-watch/contracts'],
+      exclude: isDev ? ['@yearn-oracle-watch/sdk', '@yearn-oracle-watch/contracts'] : [],
     },
     define: {
       global: 'globalThis',
       // Define environment variables for the frontend
-      'import.meta.env.VITE_RPC_URI_FOR_1': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_1
-      ),
-      'import.meta.env.VITE_RPC_URI_FOR_10': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_10
-      ),
+      'import.meta.env.VITE_RPC_URI_FOR_1': JSON.stringify(envWithVitePrefix.VITE_RPC_URI_FOR_1),
+      'import.meta.env.VITE_RPC_URI_FOR_10': JSON.stringify(envWithVitePrefix.VITE_RPC_URI_FOR_10),
       'import.meta.env.VITE_RPC_URI_FOR_100': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_100
+        envWithVitePrefix.VITE_RPC_URI_FOR_100,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_137': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_137
+        envWithVitePrefix.VITE_RPC_URI_FOR_137,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_146': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_146
+        envWithVitePrefix.VITE_RPC_URI_FOR_146,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_8453': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_8453
+        envWithVitePrefix.VITE_RPC_URI_FOR_8453,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_42161': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_42161
+        envWithVitePrefix.VITE_RPC_URI_FOR_42161,
+      ),
+      'import.meta.env.VITE_RPC_URI_FOR_747474': JSON.stringify(
+        envWithVitePrefix.VITE_RPC_URI_FOR_747474,
       ),
       'import.meta.env.VITE_WALLETCONNECT_PROJECT_ID': JSON.stringify(
-        envWithVitePrefix.VITE_WALLETCONNECT_PROJECT_ID
+        envWithVitePrefix.VITE_WALLETCONNECT_PROJECT_ID,
       ),
     },
     server: {
@@ -86,14 +82,8 @@ export default defineConfig(({ mode }) => {
         // In production, Vite will use the package.json exports
         ...(isDev
           ? {
-              '@yearn-oracle-watch/sdk': path.resolve(
-                __dirname,
-                '../sdk/src/index.ts'
-              ),
-              '@yearn-oracle-watch/contracts': path.resolve(
-                __dirname,
-                '../contracts/src/wagmi.ts'
-              ),
+              '@yearn-oracle-watch/sdk': path.resolve(__dirname, '../sdk/src/index.ts'),
+              '@yearn-oracle-watch/contracts': path.resolve(__dirname, '../contracts/src/wagmi.ts'),
             }
           : {}),
       },

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig(({ mode }) => {
     VITE_RPC_URI_FOR_146: env.RPC_URI_FOR_146,
     VITE_RPC_URI_FOR_8453: env.RPC_URI_FOR_8453,
     VITE_RPC_URI_FOR_42161: env.RPC_URI_FOR_42161,
+    VITE_RPC_URI_FOR_747474: env.RPC_URI_FOR_747474,
     VITE_WALLETCONNECT_PROJECT_ID: env.WALLETCONNECT_PROJECT_ID,
   }
 
@@ -35,42 +36,35 @@ export default defineConfig(({ mode }) => {
       alias: {
         '@': path.resolve(__dirname, 'src'),
         // Use source files in test environment for better debugging
-        '@yearn-oracle-watch/sdk': path.resolve(
-          __dirname,
-          '../sdk/src/index.ts'
-        ),
-        '@yearn-oracle-watch/contracts': path.resolve(
-          __dirname,
-          '../contracts/src/wagmi.ts'
-        ),
+        '@yearn-oracle-watch/sdk': path.resolve(__dirname, '../sdk/src/index.ts'),
+        '@yearn-oracle-watch/contracts': path.resolve(__dirname, '../contracts/src/wagmi.ts'),
       },
     },
     define: {
       global: 'globalThis',
       // Make environment variables available to the test code
-      'import.meta.env.VITE_RPC_URI_FOR_1': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_1
-      ),
-      'import.meta.env.VITE_RPC_URI_FOR_10': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_10
-      ),
+      'import.meta.env.VITE_RPC_URI_FOR_1': JSON.stringify(envWithVitePrefix.VITE_RPC_URI_FOR_1),
+      'import.meta.env.VITE_RPC_URI_FOR_10': JSON.stringify(envWithVitePrefix.VITE_RPC_URI_FOR_10),
       'import.meta.env.VITE_RPC_URI_FOR_100': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_100
+        envWithVitePrefix.VITE_RPC_URI_FOR_100,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_137': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_137
+        envWithVitePrefix.VITE_RPC_URI_FOR_137,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_146': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_146
+        envWithVitePrefix.VITE_RPC_URI_FOR_146,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_8453': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_8453
+        envWithVitePrefix.VITE_RPC_URI_FOR_8453,
       ),
       'import.meta.env.VITE_RPC_URI_FOR_42161': JSON.stringify(
-        envWithVitePrefix.VITE_RPC_URI_FOR_42161
+        envWithVitePrefix.VITE_RPC_URI_FOR_42161,
+      ),
+      'import.meta.env.VITE_RPC_URI_FOR_747474': JSON.stringify(
+        envWithVitePrefix.VITE_RPC_URI_FOR_747474,
       ),
       'import.meta.env.VITE_WALLETCONNECT_PROJECT_ID': JSON.stringify(
-        envWithVitePrefix.VITE_WALLETCONNECT_PROJECT_ID
+        envWithVitePrefix.VITE_WALLETCONNECT_PROJECT_ID,
       ),
     },
     test: {
@@ -80,15 +74,7 @@ export default defineConfig(({ mode }) => {
       css: true,
       // Test file patterns
       include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-      exclude: [
-        'node_modules',
-        'dist',
-        'build',
-        '.next',
-        '.nuxt',
-        '.vercel',
-        '.swc',
-      ],
+      exclude: ['node_modules', 'dist', 'build', '.next', '.nuxt', '.vercel', '.swc'],
       // Timeouts for blockchain operations
       testTimeout: 60000, // Increased for blockchain calls
       hookTimeout: 30000,
@@ -101,13 +87,7 @@ export default defineConfig(({ mode }) => {
       coverage: {
         provider: 'v8',
         reporter: ['text', 'json', 'html'],
-        exclude: [
-          'node_modules/',
-          'src/tests/',
-          '**/*.d.ts',
-          '**/*.config.*',
-          '**/coverage/**',
-        ],
+        exclude: ['node_modules/', 'src/tests/', '**/*.d.ts', '**/*.config.*', '**/coverage/**'],
       },
     },
   }

--- a/packages/sdk/src/datasources/KongDataSource.ts
+++ b/packages/sdk/src/datasources/KongDataSource.ts
@@ -49,6 +49,7 @@ export class KongDataSource extends BaseDataSource {
     const data = await this.gql.GetVaultData()
     const vaults = (data.vaults || [])
       .filter((vault): vault is NonNullable<typeof vault> => vault !== null)
+      .filter((vault) => !vault.meta?.isHidden)
       .map((vault) => ({
         address: (vault.address || '') as Address,
         symbol: vault.symbol || '',
@@ -61,6 +62,6 @@ export class KongDataSource extends BaseDataSource {
           symbol: vault.asset?.symbol || '',
         },
       }))
-    return filterVaultsByChainIds(vaults, [747474, 250])
+    return filterVaultsByChainIds(vaults, [250])
   }
 }

--- a/packages/sdk/src/queries/kong/generated.ts
+++ b/packages/sdk/src/queries/kong/generated.ts
@@ -62,8 +62,11 @@ export type kong_Apy = {
   grossApr?: Maybe<Scalars['Float']['output']>;
   inceptionNet?: Maybe<Scalars['Float']['output']>;
   monthlyNet?: Maybe<Scalars['Float']['output']>;
+  monthlyPricePerShare?: Maybe<Scalars['BigInt']['output']>;
   net?: Maybe<Scalars['Float']['output']>;
+  pricePerShare?: Maybe<Scalars['BigInt']['output']>;
   weeklyNet?: Maybe<Scalars['Float']['output']>;
+  weeklyPricePerShare?: Maybe<Scalars['BigInt']['output']>;
 };
 
 export enum kong_CacheControlScope {
@@ -116,9 +119,40 @@ export type kong_Erc20 = {
   symbol?: Maybe<Scalars['String']['output']>;
 };
 
+export type kong_EstimatedApr = {
+  apr?: Maybe<Scalars['Float']['output']>;
+  apy?: Maybe<Scalars['Float']['output']>;
+  components: kong_EstimatedAprComponents;
+  type: Scalars['String']['output'];
+};
+
+export type kong_EstimatedAprComponents = {
+  baseAPR?: Maybe<Scalars['Float']['output']>;
+  baseNetAPR?: Maybe<Scalars['Float']['output']>;
+  baseNetAPY?: Maybe<Scalars['Float']['output']>;
+  boost?: Maybe<Scalars['Float']['output']>;
+  boostedAPR?: Maybe<Scalars['Float']['output']>;
+  cvxAPR?: Maybe<Scalars['Float']['output']>;
+  grossAPR?: Maybe<Scalars['Float']['output']>;
+  keepCRV?: Maybe<Scalars['Float']['output']>;
+  keepVelo?: Maybe<Scalars['Float']['output']>;
+  lockerBonusAPR?: Maybe<Scalars['Float']['output']>;
+  lockerBonusAPY?: Maybe<Scalars['Float']['output']>;
+  poolAPY?: Maybe<Scalars['Float']['output']>;
+  rewardsAPR?: Maybe<Scalars['Float']['output']>;
+  rewardsAPY?: Maybe<Scalars['Float']['output']>;
+};
+
 export type kong_Fees = {
   managementFee?: Maybe<Scalars['Float']['output']>;
   performanceFee?: Maybe<Scalars['Float']['output']>;
+};
+
+export type kong_Historical = {
+  inceptionNet?: Maybe<Scalars['Float']['output']>;
+  monthlyNet?: Maybe<Scalars['Float']['output']>;
+  net?: Maybe<Scalars['Float']['output']>;
+  weeklyNet?: Maybe<Scalars['Float']['output']>;
 };
 
 export type kong_IngestCpu = {
@@ -146,6 +180,12 @@ export type kong_LenderStatus = {
   assets?: Maybe<Scalars['BigInt']['output']>;
   name?: Maybe<Scalars['String']['output']>;
   rate?: Maybe<Scalars['BigInt']['output']>;
+};
+
+export type kong_Locker = {
+  cooldownDuration?: Maybe<Scalars['Float']['output']>;
+  lockerBonus?: Maybe<Scalars['Float']['output']>;
+  withdrawalWindow?: Maybe<Scalars['Float']['output']>;
 };
 
 export type kong_Monitor = {
@@ -178,6 +218,12 @@ export type kong_NewYieldSplitterLog = {
   want: Scalars['String']['output'];
 };
 
+export type kong_Oracle = {
+  apr?: Maybe<Scalars['Float']['output']>;
+  apy?: Maybe<Scalars['Float']['output']>;
+  netAPR?: Maybe<Scalars['Float']['output']>;
+};
+
 export type kong_Output = {
   address: Scalars['String']['output'];
   chainId: Scalars['Int']['output'];
@@ -186,6 +232,12 @@ export type kong_Output = {
   period: Scalars['String']['output'];
   time?: Maybe<Scalars['BigInt']['output']>;
   value: Scalars['Float']['output'];
+};
+
+export type kong_Performance = {
+  estimated?: Maybe<kong_EstimatedApr>;
+  historical?: Maybe<kong_Historical>;
+  oracle?: Maybe<kong_Oracle>;
 };
 
 export type kong_Price = {
@@ -404,6 +456,7 @@ export type kong_QueryVaultsArgs = {
   apiVersion?: InputMaybe<Scalars['String']['input']>;
   chainId?: InputMaybe<Scalars['Int']['input']>;
   erc4626?: InputMaybe<Scalars['Boolean']['input']>;
+  origin?: InputMaybe<Scalars['String']['input']>;
   riskLevel?: InputMaybe<Scalars['Int']['input']>;
   unratedOnly?: InputMaybe<Scalars['Boolean']['input']>;
   v3?: InputMaybe<Scalars['Boolean']['input']>;
@@ -542,6 +595,25 @@ export type kong_Sparklines = {
   tvl?: Maybe<Array<Maybe<kong_SparklinePoint>>>;
 };
 
+export type kong_Staking = {
+  address?: Maybe<Scalars['String']['output']>;
+  available?: Maybe<Scalars['Boolean']['output']>;
+  rewards?: Maybe<Array<kong_StakingReward>>;
+  source?: Maybe<Scalars['String']['output']>;
+};
+
+export type kong_StakingReward = {
+  address: Scalars['String']['output'];
+  apr: Scalars['Float']['output'];
+  decimals: Scalars['Int']['output'];
+  finishedAt: Scalars['BigInt']['output'];
+  isFinished: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  perWeek: Scalars['Float']['output'];
+  price: Scalars['Float']['output'];
+  symbol: Scalars['String']['output'];
+};
+
 export type kong_Strategy = {
   DOMAIN_SEPARATOR?: Maybe<Scalars['String']['output']>;
   FACTORY?: Maybe<Scalars['String']['output']>;
@@ -549,6 +621,7 @@ export type kong_Strategy = {
   MIN_FEE?: Maybe<Scalars['Int']['output']>;
   address?: Maybe<Scalars['String']['output']>;
   apiVersion?: Maybe<Scalars['String']['output']>;
+  apy?: Maybe<kong_Apy>;
   balanceOfWant?: Maybe<Scalars['BigInt']['output']>;
   baseFeeOracle?: Maybe<Scalars['String']['output']>;
   chainId?: Maybe<Scalars['Int']['output']>;
@@ -583,6 +656,7 @@ export type kong_Strategy = {
   metadataURI?: Maybe<Scalars['String']['output']>;
   minReportDelay?: Maybe<Scalars['BigInt']['output']>;
   name?: Maybe<Scalars['String']['output']>;
+  origin?: Maybe<Scalars['String']['output']>;
   pendingManagement?: Maybe<Scalars['String']['output']>;
   performanceFee?: Maybe<Scalars['Int']['output']>;
   performanceFeeRecipient?: Maybe<Scalars['String']['output']>;
@@ -592,6 +666,7 @@ export type kong_Strategy = {
   proxy?: Maybe<Scalars['String']['output']>;
   rewards?: Maybe<Scalars['String']['output']>;
   risk?: Maybe<kong_RiskScoreLegacy>;
+  sparklines?: Maybe<kong_Sparklines>;
   stakedBalance?: Maybe<Scalars['BigInt']['output']>;
   strategist?: Maybe<Scalars['String']['output']>;
   symbol?: Maybe<Scalars['String']['output']>;
@@ -601,6 +676,7 @@ export type kong_Strategy = {
   totalIdle?: Maybe<Scalars['BigInt']['output']>;
   totalSupply?: Maybe<Scalars['BigInt']['output']>;
   tradeFactory?: Maybe<Scalars['String']['output']>;
+  tvl?: Maybe<kong_SparklinePoint>;
   v3?: Maybe<Scalars['Boolean']['output']>;
   vault?: Maybe<Scalars['String']['output']>;
   want?: Maybe<Scalars['String']['output']>;
@@ -610,6 +686,7 @@ export type kong_Strategy = {
 export type kong_StrategyMeta = {
   description?: Maybe<Scalars['String']['output']>;
   displayName?: Maybe<Scalars['String']['output']>;
+  isRetired?: Maybe<Scalars['Boolean']['output']>;
   protocols?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
 };
 
@@ -646,10 +723,12 @@ export type kong_Thing = {
 
 export type kong_TokenMeta = {
   category?: Maybe<Scalars['String']['output']>;
+  decimals?: Maybe<Scalars['Int']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   displayName?: Maybe<Scalars['String']['output']>;
   displaySymbol?: Maybe<Scalars['String']['output']>;
   icon?: Maybe<Scalars['String']['output']>;
+  symbol?: Maybe<Scalars['String']['output']>;
   type?: Maybe<Scalars['String']['output']>;
 };
 
@@ -715,12 +794,15 @@ export type kong_Vault = {
   lastReportDetail?: Maybe<kong_ReportDetail>;
   lockedProfit?: Maybe<Scalars['BigInt']['output']>;
   lockedProfitDegradation?: Maybe<Scalars['BigInt']['output']>;
+  locker?: Maybe<kong_Locker>;
   management?: Maybe<Scalars['String']['output']>;
   managementFee?: Maybe<Scalars['BigInt']['output']>;
   maxAvailableShares?: Maybe<Scalars['BigInt']['output']>;
   meta?: Maybe<kong_VaultMeta>;
   minimum_total_idle?: Maybe<Scalars['BigInt']['output']>;
   name?: Maybe<Scalars['String']['output']>;
+  origin?: Maybe<Scalars['String']['output']>;
+  performance?: Maybe<kong_Performance>;
   performanceFee?: Maybe<Scalars['BigInt']['output']>;
   pricePerShare?: Maybe<Scalars['BigInt']['output']>;
   profitMaxUnlockTime?: Maybe<Scalars['BigInt']['output']>;
@@ -733,6 +815,7 @@ export type kong_Vault = {
   role_manager?: Maybe<Scalars['String']['output']>;
   roles?: Maybe<Array<Maybe<kong_Role>>>;
   sparklines?: Maybe<kong_Sparklines>;
+  staking?: Maybe<kong_Staking>;
   strategies?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   symbol?: Maybe<Scalars['String']['output']>;
   token?: Maybe<Scalars['String']['output']>;
@@ -752,11 +835,48 @@ export type kong_Vault = {
 };
 
 export type kong_VaultMeta = {
+  category?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   displayName?: Maybe<Scalars['String']['output']>;
   displaySymbol?: Maybe<Scalars['String']['output']>;
+  inclusion?: Maybe<kong_VaultMetaInclusion>;
+  isAggregator?: Maybe<Scalars['Boolean']['output']>;
+  isAutomated?: Maybe<Scalars['Boolean']['output']>;
+  isBoosted?: Maybe<Scalars['Boolean']['output']>;
+  isHidden?: Maybe<Scalars['Boolean']['output']>;
+  isHighlighted?: Maybe<Scalars['Boolean']['output']>;
+  isPool?: Maybe<Scalars['Boolean']['output']>;
+  isRetired?: Maybe<Scalars['Boolean']['output']>;
+  kind?: Maybe<Scalars['String']['output']>;
+  migration?: Maybe<kong_VaultMetaMigration>;
   protocols?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  shouldUseV2APR?: Maybe<Scalars['Boolean']['output']>;
+  sourceURI?: Maybe<Scalars['String']['output']>;
+  stability?: Maybe<kong_VaultMetaStability>;
   token?: Maybe<kong_TokenMeta>;
+  type?: Maybe<Scalars['String']['output']>;
+  uiNotice?: Maybe<Scalars['String']['output']>;
+};
+
+export type kong_VaultMetaInclusion = {
+  isCove?: Maybe<Scalars['Boolean']['output']>;
+  isGimme?: Maybe<Scalars['Boolean']['output']>;
+  isKatana?: Maybe<Scalars['Boolean']['output']>;
+  isMorpho?: Maybe<Scalars['Boolean']['output']>;
+  isPoolTogether?: Maybe<Scalars['Boolean']['output']>;
+  isPublicERC4626?: Maybe<Scalars['Boolean']['output']>;
+  isYearn?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type kong_VaultMetaMigration = {
+  available: Scalars['Boolean']['output'];
+  contract?: Maybe<Scalars['String']['output']>;
+  target?: Maybe<Scalars['String']['output']>;
+};
+
+export type kong_VaultMetaStability = {
+  stability: Scalars['String']['output'];
+  stableBaseAsset?: Maybe<Scalars['String']['output']>;
 };
 
 export type kong_VaultReport = {
@@ -812,7 +932,7 @@ export type kong_VestingEscrowCreatedLog = {
 export type kong_GetVaultDataQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type kong_GetVaultDataQuery = { vaults?: Array<{ address?: string | null, symbol?: string | null, name?: string | null, chainId?: number | null, asset?: { decimals?: number | null, address?: string | null, name?: string | null, symbol?: string | null } | null } | null> | null };
+export type kong_GetVaultDataQuery = { vaults?: Array<{ address?: string | null, symbol?: string | null, name?: string | null, chainId?: number | null, meta?: { isHidden?: boolean | null } | null, asset?: { decimals?: number | null, address?: string | null, name?: string | null, symbol?: string | null } | null } | null> | null };
 
 
 export const GetVaultDataDocument = /*#__PURE__*/ gql`
@@ -822,6 +942,9 @@ export const GetVaultDataDocument = /*#__PURE__*/ gql`
     symbol
     name
     chainId
+    meta {
+      isHidden
+    }
     asset {
       decimals
       address

--- a/packages/sdk/src/queries/kong/query.graphql
+++ b/packages/sdk/src/queries/kong/query.graphql
@@ -4,6 +4,9 @@ query GetVaultData {
     symbol
     name
     chainId
+    meta {
+      isHidden
+    }
     asset {
       decimals
       address

--- a/packages/sdk/src/queries/kong/schema.graphql
+++ b/packages/sdk/src/queries/kong/schema.graphql
@@ -48,8 +48,11 @@ type Apy {
   grossApr: Float
   inceptionNet: Float
   monthlyNet: Float
+  monthlyPricePerShare: BigInt
   net: Float
+  pricePerShare: BigInt
   weeklyNet: Float
+  weeklyPricePerShare: BigInt
 }
 
 """BigInt override"""
@@ -105,9 +108,40 @@ type Erc20 {
   symbol: String
 }
 
+type EstimatedApr {
+  apr: Float
+  apy: Float
+  components: EstimatedAprComponents!
+  type: String!
+}
+
+type EstimatedAprComponents {
+  baseAPR: Float
+  baseNetAPR: Float
+  baseNetAPY: Float
+  boost: Float
+  boostedAPR: Float
+  cvxAPR: Float
+  grossAPR: Float
+  keepCRV: Float
+  keepVelo: Float
+  lockerBonusAPR: Float
+  lockerBonusAPY: Float
+  poolAPY: Float
+  rewardsAPR: Float
+  rewardsAPY: Float
+}
+
 type Fees {
   managementFee: Float
   performanceFee: Float
+}
+
+type Historical {
+  inceptionNet: Float
+  monthlyNet: Float
+  net: Float
+  weeklyNet: Float
 }
 
 type IngestCpu {
@@ -135,6 +169,12 @@ type LenderStatus {
   assets: BigInt
   name: String
   rate: BigInt
+}
+
+type Locker {
+  cooldownDuration: Float
+  lockerBonus: Float
+  withdrawalWindow: Float
 }
 
 type Monitor {
@@ -167,6 +207,12 @@ type NewYieldSplitterLog {
   want: String!
 }
 
+type Oracle {
+  apr: Float
+  apy: Float
+  netAPR: Float
+}
+
 type Output {
   address: String!
   chainId: Int!
@@ -175,6 +221,12 @@ type Output {
   period: String!
   time: BigInt
   value: Float!
+}
+
+type Performance {
+  estimated: EstimatedApr
+  historical: Historical
+  oracle: Oracle
 }
 
 type Price {
@@ -226,7 +278,7 @@ type Query {
   vaultAccounts(chainId: Int, vault: String): [AccountRole]
   vaultReports(address: String, chainId: Int): [VaultReport]
   vaultStrategies(chainId: Int, vault: String): [Strategy]
-  vaults(addresses: [String], apiVersion: String, chainId: Int, erc4626: Boolean, riskLevel: Int, unratedOnly: Boolean, v3: Boolean, vaultType: Int, yearn: Boolean): [Vault]
+  vaults(addresses: [String], apiVersion: String, chainId: Int, erc4626: Boolean, origin: String, riskLevel: Int, unratedOnly: Boolean, v3: Boolean, vaultType: Int, yearn: Boolean): [Vault]
   vestingEscrowCreatedLogs(recipient: String): [VestingEscrowCreatedLog]
 }
 
@@ -356,6 +408,25 @@ type Sparklines {
   tvl: [SparklinePoint]
 }
 
+type Staking {
+  address: String
+  available: Boolean
+  rewards: [StakingReward!]
+  source: String
+}
+
+type StakingReward {
+  address: String!
+  apr: Float!
+  decimals: Int!
+  finishedAt: BigInt!
+  isFinished: Boolean!
+  name: String!
+  perWeek: Float!
+  price: Float!
+  symbol: String!
+}
+
 type Strategy {
   DOMAIN_SEPARATOR: String
   FACTORY: String
@@ -363,6 +434,7 @@ type Strategy {
   MIN_FEE: Int
   address: String
   apiVersion: String
+  apy: Apy
   balanceOfWant: BigInt
   baseFeeOracle: String
   chainId: Int
@@ -397,6 +469,7 @@ type Strategy {
   metadataURI: String
   minReportDelay: BigInt
   name: String
+  origin: String
   pendingManagement: String
   performanceFee: Int
   performanceFeeRecipient: String
@@ -406,6 +479,7 @@ type Strategy {
   proxy: String
   rewards: String
   risk: RiskScoreLegacy
+  sparklines: Sparklines
   stakedBalance: BigInt
   strategist: String
   symbol: String
@@ -415,6 +489,7 @@ type Strategy {
   totalIdle: BigInt
   totalSupply: BigInt
   tradeFactory: String
+  tvl: SparklinePoint
   v3: Boolean
   vault: String
   want: String
@@ -424,6 +499,7 @@ type Strategy {
 type StrategyMeta {
   description: String
   displayName: String
+  isRetired: Boolean
   protocols: [String]
 }
 
@@ -460,10 +536,12 @@ type Thing {
 
 type TokenMeta {
   category: String
+  decimals: Int
   description: String
   displayName: String
   displaySymbol: String
   icon: String
+  symbol: String
   type: String
 }
 
@@ -529,12 +607,15 @@ type Vault {
   lastReportDetail: ReportDetail
   lockedProfit: BigInt
   lockedProfitDegradation: BigInt
+  locker: Locker
   management: String
   managementFee: BigInt
   maxAvailableShares: BigInt
   meta: VaultMeta
   minimum_total_idle: BigInt
   name: String
+  origin: String
+  performance: Performance
   performanceFee: BigInt
   pricePerShare: BigInt
   profitMaxUnlockTime: BigInt
@@ -547,6 +628,7 @@ type Vault {
   role_manager: String
   roles: [Role]
   sparklines: Sparklines
+  staking: Staking
   strategies: [String]
   symbol: String
   token: String
@@ -566,11 +648,48 @@ type Vault {
 }
 
 type VaultMeta {
+  category: String
   description: String
   displayName: String
   displaySymbol: String
+  inclusion: VaultMetaInclusion
+  isAggregator: Boolean
+  isAutomated: Boolean
+  isBoosted: Boolean
+  isHidden: Boolean
+  isHighlighted: Boolean
+  isPool: Boolean
+  isRetired: Boolean
+  kind: String
+  migration: VaultMetaMigration
   protocols: [String]
+  shouldUseV2APR: Boolean
+  sourceURI: String
+  stability: VaultMetaStability
   token: TokenMeta
+  type: String
+  uiNotice: String
+}
+
+type VaultMetaInclusion {
+  isCove: Boolean
+  isGimme: Boolean
+  isKatana: Boolean
+  isMorpho: Boolean
+  isPoolTogether: Boolean
+  isPublicERC4626: Boolean
+  isYearn: Boolean
+}
+
+type VaultMetaMigration {
+  available: Boolean!
+  contract: String
+  target: String
+}
+
+type VaultMetaStability {
+  stability: String!
+  stableBaseAsset: String
 }
 
 type VaultReport {


### PR DESCRIPTION
## Summary
- add header links for GitHub, vaults, and the oracle contract
- add Katana chain support and include it in vault discovery
- add a Yearn-style chain selector to the vault modal with chain badges on vault icons
- hide Kong vaults marked hidden and format amount inputs with commas

## Verification
- bunx biome check packages/app/src/components/shared/Modal.tsx packages/app/src/components/pages/home/VaultQueryCard.tsx packages/app/src/components/shared/VaultListItem.tsx
- bun run --filter ./packages/app build