### PR TITLE
Improve featured vault oracle handling and selection

### DIFF
--- a/packages/app/src/components/pages/home/VaultQueryCard.tsx
+++ b/packages/app/src/components/pages/home/VaultQueryCard.tsx
@@ -607,7 +607,7 @@ const VaultCategoryTabs: React.FC<{
 }> = ({ counts, selectedCategory, onSelect }) => {
   const tabs: Array<{ id: VaultCategory; label: string }> = [
     { id: 'allocator', label: 'Allocator Vaults' },
-    { id: 'strategy', label: 'Tokenized Strategy Vaults' },
+    { id: 'strategy', label: 'Tokenized Strategies' },
   ]
 
   return (

--- a/packages/app/src/components/pages/home/VaultQueryCard.tsx
+++ b/packages/app/src/components/pages/home/VaultQueryCard.tsx
@@ -1,6 +1,7 @@
 import Button from '@/components/shared/Button'
 import { InputDepositAmount } from '@/components/shared/InputDepositAmount'
 import { Modal } from '@/components/shared/Modal'
+import { Tooltip } from '@/components/shared/Tooltip'
 import { VaultListItem } from '@/components/shared/VaultListItem'
 import VaultSelectButton, { type KongVault } from '@/components/shared/VaultSelectButton'
 import YearnLoader from '@/components/shared/YearnLoader'
@@ -13,7 +14,8 @@ import { type VaultData, useGetVaults } from '@/hooks/useGetVaults'
 import { useInput } from '@/hooks/useInput'
 import { usePreloadTokenImages } from '@/hooks/usePreloadTokenImages'
 import { findTokenPrice, useTokenPrices } from '@/hooks/useTokenPrices'
-import { calculateDelta } from '@yearn-oracle-watch/sdk'
+import { calculateDelta, isYvUsdVault } from '@yearn-oracle-watch/sdk'
+import { TriangleAlert } from 'lucide-react'
 import React from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Address, isAddress } from 'viem'
@@ -39,6 +41,8 @@ type ChainOption = {
   count: number
 }
 
+type VaultCategory = VaultData['category']
+
 // Debounce utility function
 const debounce = <T extends (...args: any[]) => void>(
   func: T,
@@ -62,6 +66,7 @@ const VaultQueryCard: React.FC = () => {
   const [deltaValue, setDeltaValue] = React.useState<bigint | undefined>(undefined)
   const [searchTerm, setSearchTerm] = React.useState('')
   const [selectedChainId, setSelectedChainId] = React.useState<number | null>(null)
+  const [selectedCategory, setSelectedCategory] = React.useState<VaultCategory>('allocator')
   const [filteredVaults, setFilteredVaults] = React.useState<VaultData[]>([])
   const { data: discoveredVaults, isLoading: isDiscovering } = useDiscoverVaultByAddress(searchTerm)
 
@@ -188,6 +193,31 @@ const VaultQueryCard: React.FC = () => {
     return displayVaults.filter((vault) => vault.chainId === selectedChainId)
   }, [displayVaults, selectedChainId])
 
+  const categoryCounts = React.useMemo(
+    () =>
+      chainFilteredVaults.reduce(
+        (counts, vault) => {
+          counts[vault.category] += 1
+          return counts
+        },
+        { allocator: 0, strategy: 0 } satisfies Record<VaultCategory, number>,
+      ),
+    [chainFilteredVaults],
+  )
+
+  React.useEffect(() => {
+    if (categoryCounts[selectedCategory] > 0) return
+    const alternateCategory = selectedCategory === 'allocator' ? 'strategy' : 'allocator'
+    if (categoryCounts[alternateCategory] > 0) {
+      setSelectedCategory(alternateCategory)
+    }
+  }, [categoryCounts, selectedCategory])
+
+  const visibleVaults = React.useMemo(
+    () => chainFilteredVaults.filter((vault) => vault.category === selectedCategory),
+    [chainFilteredVaults, selectedCategory],
+  )
+
   // Track which items came from on-chain discovery for UI indicators
   const discoveredSet = React.useMemo(() => {
     const set = new Set<string>()
@@ -197,10 +227,6 @@ const VaultQueryCard: React.FC = () => {
 
   const handleSearchChange = (value: string) => {
     setSearchTerm(value)
-  }
-
-  const clearSearch = () => {
-    setSearchTerm('')
   }
 
   // APR Oracle integration
@@ -244,6 +270,9 @@ const VaultQueryCard: React.FC = () => {
   }
 
   const balance = 0n
+  const usesExternalApiOracle = Boolean(
+    selectedVault?.address && isYvUsdVault(Number(selectedVault.chainId), selectedVault.address),
+  )
 
   // Find the full vault with logos for InputDepositAmount
   const selectedVaultWithLogos = data?.find((vault) => vault.address === selectedVault?.address)
@@ -297,11 +326,16 @@ const VaultQueryCard: React.FC = () => {
                       selectedChainId={selectedChainId}
                       onSelect={setSelectedChainId}
                     />
+                    <VaultCategoryTabs
+                      counts={categoryCounts}
+                      selectedCategory={selectedCategory}
+                      onSelect={setSelectedCategory}
+                    />
                   </div>
                 }
               >
                 <ModalData
-                  data={chainFilteredVaults}
+                  data={visibleVaults}
                   searchTerm={searchTerm}
                   isLoading={isLoading}
                   error={error}
@@ -309,7 +343,7 @@ const VaultQueryCard: React.FC = () => {
                   unfilteredResultCount={displayVaults.length}
                   discoveredSet={discoveredSet}
                   isProbingOnChain={
-                    isAddress(searchTerm) && chainFilteredVaults.length === 0 && isDiscovering
+                    isAddress(searchTerm) && visibleVaults.length === 0 && isDiscovering
                   }
                   onClearFilters={() => setSelectedChainId(null)}
                   onClose={handleCloseVaultModal}
@@ -379,11 +413,27 @@ const VaultQueryCard: React.FC = () => {
                   </div>
                 </div>
                 <div className="w-full h-8 px-5 overflow-hidden border-b border-[#1A51B2] flex justify-center items-center gap-2.5">
-                  <div className="flex-1 text-[#1E1E1E] text-base font-normal leading-8 font-aeonik">
-                    Projected APY:
+                  <div className="flex flex-1 items-center gap-1.5 text-[#1E1E1E] text-base font-normal leading-8 font-aeonik">
+                    <span>Projected APY:</span>
+                    {usesExternalApiOracle && (
+                      <Tooltip
+                        content="Projected APY is unavailable because this oracle reads from an external API and does not calculate deposit deltas."
+                        position="top"
+                      >
+                        <button
+                          type="button"
+                          className="flex h-5 w-5 items-center justify-center rounded text-amber-600 transition-colors hover:bg-amber-50 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-amber-600"
+                          aria-label="Why projected APY is unavailable"
+                        >
+                          <TriangleAlert className="h-4 w-4" aria-hidden="true" />
+                        </button>
+                      </Tooltip>
+                    )}
                   </div>
                   <div className="flex-1 text-right text-base font-normal text-sm leading-8 font-aeonik-mono">
-                    {deltaValue !== undefined && deltaValue > 0n ? (
+                    {usesExternalApiOracle ? (
+                      <span className="text-[#9E9E9E]">N/A</span>
+                    ) : deltaValue !== undefined && deltaValue > 0n ? (
                       isAprOracleLoading ? (
                         <span className="text-[#9E9E9E]">Loading...</span>
                       ) : aprOracleError ? (
@@ -403,7 +453,9 @@ const VaultQueryCard: React.FC = () => {
                     Percent Change:
                   </div>
                   <div className="flex-1 text-right text-base font-normal text-sm leading-8 font-aeonik-mono">
-                    {deltaValue !== undefined && deltaValue > 0n ? (
+                    {usesExternalApiOracle ? (
+                      <span className="text-[#9E9E9E]">N/A</span>
+                    ) : deltaValue !== undefined && deltaValue > 0n ? (
                       aprOracleResult?.percentChange ? (
                         <span
                           className={
@@ -547,6 +599,41 @@ const ChainSelector: React.FC<{
     </div>
   </div>
 )
+
+const VaultCategoryTabs: React.FC<{
+  counts: Record<VaultCategory, number>
+  selectedCategory: VaultCategory
+  onSelect: (category: VaultCategory) => void
+}> = ({ counts, selectedCategory, onSelect }) => {
+  const tabs: Array<{ id: VaultCategory; label: string }> = [
+    { id: 'allocator', label: 'Allocator Vaults' },
+    { id: 'strategy', label: 'Tokenized Strategy Vaults' },
+  ]
+
+  return (
+    <div className="grid w-full grid-cols-2 border-b border-black/10" role="tablist">
+      {tabs.map((tab) => {
+        const selected = tab.id === selectedCategory
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onSelect(tab.id)}
+            className={`min-h-10 border-b-2 px-2 py-2 text-center text-xs font-aeonik transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#1A51B2] ${
+              selected
+                ? 'border-[#1A51B2] font-bold text-[#1A51B2]'
+                : 'border-transparent text-[#5C5C5C] hover:bg-black/5 hover:text-[#1E1E1E]'
+            }`}
+          >
+            {tab.label} <span className="font-aeonik-mono">({counts[tab.id]})</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
 
 const ModalData: React.FC<ModalDataProps> = ({
   data,

--- a/packages/app/src/components/shared/Tooltip.tsx
+++ b/packages/app/src/components/shared/Tooltip.tsx
@@ -62,6 +62,8 @@ export const Tooltip: FC<TooltipProps> = ({ children, content, position = 'top' 
         className="inline-block"
         onMouseEnter={() => setIsVisible(true)}
         onMouseLeave={() => setIsVisible(false)}
+        onFocus={() => setIsVisible(true)}
+        onBlur={() => setIsVisible(false)}
       >
         {children}
       </div>
@@ -69,7 +71,7 @@ export const Tooltip: FC<TooltipProps> = ({ children, content, position = 'top' 
         createPortal(
           <div
             ref={tooltipRef}
-            className="fixed z-[9999] px-3 py-2 text-sm text-white bg-gray-900 rounded-lg shadow-lg whitespace-nowrap pointer-events-none"
+            className="fixed z-[9999] max-w-[min(24rem,calc(100vw-1rem))] px-3 py-2 text-left text-sm text-white bg-gray-900 rounded-lg shadow-lg whitespace-normal pointer-events-none"
             style={{ top: `${coords.top}px`, left: `${coords.left}px` }}
           >
             {content}

--- a/packages/app/src/components/shared/VaultListItem.tsx
+++ b/packages/app/src/components/shared/VaultListItem.tsx
@@ -26,7 +26,7 @@ export const VaultListItem: React.FC<VaultListItemProps> = ({
     src: imageSrc,
     isLoading: imageLoading,
     error: imageError,
-  } = useTokenImage(vault.chainId, vault.asset.address)
+  } = useTokenImage(vault.chainId, vault.iconAddress || vault.asset.address)
 
   // Helper function to highlight matching text
   const highlightMatch = (text: string, searchTerm?: string) => {

--- a/packages/app/src/components/shared/VaultSelectButton.tsx
+++ b/packages/app/src/components/shared/VaultSelectButton.tsx
@@ -10,6 +10,8 @@ export type KongVault = {
   symbol?: string
   name?: string
   chainId?: number
+  category?: 'allocator' | 'strategy'
+  iconAddress?: Address
   asset?: {
     decimals?: number
     address?: Address
@@ -36,7 +38,7 @@ const VaultSelectButton: FC<VaultSelectButtonProps & ComponentProps<typeof Butto
         className="w-8 h-8 min-w-8 min-h-8 max-w-8 max-h-8 relative"
         src={getSvgAsset(
           Number(selectedVault.chainId),
-          getAddress(selectedVault.asset?.address as string),
+          getAddress((selectedVault.iconAddress || selectedVault.asset?.address) as string),
         )}
         alt={selectedVault.name as string}
         referrerPolicy="no-referrer"

--- a/packages/app/src/config/rpc.ts
+++ b/packages/app/src/config/rpc.ts
@@ -1,0 +1,8 @@
+export const resolveRpcUrls = (
+  configuredUrl: string | undefined,
+  publicUrl: string,
+  chainDefaultUrl: string,
+): string[] =>
+  [...new Set([configuredUrl?.trim(), publicUrl, chainDefaultUrl])].filter((url): url is string =>
+    Boolean(url),
+  )

--- a/packages/app/src/config/wagmi.ts
+++ b/packages/app/src/config/wagmi.ts
@@ -7,7 +7,8 @@ import {
   safeWallet,
   walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets'
-import { Config, http } from 'wagmi'
+import { fallback, http } from 'viem'
+import { Config } from 'wagmi'
 import {
   arbitrum,
   base,
@@ -18,22 +19,60 @@ import {
   sonic,
 } from 'wagmi/chains'
 import { katana } from './katana'
+import { resolveRpcUrls } from './rpc'
 
 const name = 'yearn-oracle-watch'
+const createRpcTransport = (
+  configuredUrl: string | undefined,
+  publicUrl: string,
+  chainDefaultUrl: string,
+) => fallback(resolveRpcUrls(configuredUrl, publicUrl, chainDefaultUrl).map((url) => http(url)))
 
 export const config: Config = getDefaultConfig({
   appName: name,
   projectId: import.meta.env?.VITE_WALLETCONNECT_PROJECT_ID ?? 'projectId',
   chains: [mainnet, optimism, gnosis, polygon, sonic, base, arbitrum, katana],
   transports: {
-    [mainnet.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_1}`),
-    [optimism.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_10}`),
-    [gnosis.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_100}`),
-    [polygon.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_137}`),
-    [sonic.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_146}`),
-    [base.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_8453}`),
-    [arbitrum.id]: http(`${import.meta.env.VITE_RPC_URI_FOR_42161}`),
-    [katana.id]: http(import.meta.env.VITE_RPC_URI_FOR_747474 ?? 'https://rpc.katana.network'),
+    [mainnet.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_1,
+      'https://ethereum-rpc.publicnode.com',
+      mainnet.rpcUrls.default.http[0],
+    ),
+    [optimism.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_10,
+      'https://optimism-rpc.publicnode.com',
+      optimism.rpcUrls.default.http[0],
+    ),
+    [gnosis.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_100,
+      'https://gnosis-rpc.publicnode.com',
+      gnosis.rpcUrls.default.http[0],
+    ),
+    [polygon.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_137,
+      'https://polygon-bor-rpc.publicnode.com',
+      polygon.rpcUrls.default.http[0],
+    ),
+    [sonic.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_146,
+      'https://sonic-rpc.publicnode.com',
+      sonic.rpcUrls.default.http[0],
+    ),
+    [base.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_8453,
+      'https://base-rpc.publicnode.com',
+      base.rpcUrls.default.http[0],
+    ),
+    [arbitrum.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_42161,
+      'https://arbitrum-one-rpc.publicnode.com',
+      arbitrum.rpcUrls.default.http[0],
+    ),
+    [katana.id]: createRpcTransport(
+      import.meta.env.VITE_RPC_URI_FOR_747474,
+      katana.rpcUrls.default.http[0],
+      katana.rpcUrls.default.http[0],
+    ),
   },
   wallets: [
     {

--- a/packages/app/src/constants/chains.ts
+++ b/packages/app/src/constants/chains.ts
@@ -10,7 +10,6 @@ export const CHAIN_ID_TO_NAME: Record<number, string> = {
   8453: 'Base',
   42161: 'Arbitrum',
   747474: 'Katana',
-  80094: 'Berachain',
 }
 
 export function getChainIdByName(name: string): number | undefined {
@@ -28,7 +27,6 @@ export const CHAIN_ID_TO_ICON: Record<number, string> = {
   8453: 'https://token-assets-one.vercel.app/api/chains/8453/logo-32.png',
   42161: 'https://token-assets-one.vercel.app/api/chains/42161/logo-32.png',
   747474: 'https://token-assets-one.vercel.app/api/chains/747474/logo-32.png',
-  80094: 'https://token-assets-one.vercel.app/api/chains/80094/logo-32.png',
 }
 
 export const CHAIN_ID_TO_BLOCK_EXPLORER: Record<number, string> = {
@@ -41,7 +39,6 @@ export const CHAIN_ID_TO_BLOCK_EXPLORER: Record<number, string> = {
   8453: 'https://basescan.org/',
   42161: 'https://arbiscan.io',
   747474: 'https://explorer.katanarpc.com/',
-  80094: 'https://berascan.com',
 }
 
 export const VAULT_TYPE_TO_NAME: Record<string, string> = {

--- a/packages/app/src/hooks/useGetVaults.ts
+++ b/packages/app/src/hooks/useGetVaults.ts
@@ -8,6 +8,8 @@ export type VaultData = {
   symbol: string
   name: string
   chainId: number
+  category: 'allocator' | 'strategy'
+  iconAddress?: Address
   asset: {
     decimals: number
     address: Address

--- a/packages/app/src/hooks/usePreloadTokenImages.ts
+++ b/packages/app/src/hooks/usePreloadTokenImages.ts
@@ -1,7 +1,7 @@
-import { useQueryClient } from '@tanstack/react-query'
-import { useEffect, useRef } from 'react'
 import { type VaultData } from '@/hooks/useGetVaults'
 import { getSvgAsset } from '@/utils/logos'
+import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
 
 /**
  * Hook to preload token images in the background
@@ -58,16 +58,16 @@ export function usePreloadTokenImages(vaults: VaultData[]) {
     const delay = 150 // Slightly longer delay to be server-friendly
 
     const preloadInBatches = async () => {
-      console.log(
-        `Starting to preload ${vaults.length} token images in batches of ${batchSize}`
-      )
+      console.log(`Starting to preload ${vaults.length} token images in batches of ${batchSize}`)
 
       for (let i = 0; i < vaults.length; i += batchSize) {
         const batch = vaults.slice(i, i + batchSize)
 
         // Preload all images in this batch concurrently
         await Promise.allSettled(
-          batch.map((vault) => preloadImage(vault.chainId, vault.asset.address))
+          batch.map((vault) =>
+            preloadImage(vault.chainId, vault.iconAddress || vault.asset.address),
+          ),
         )
 
         // Add delay between batches (except for the last batch)

--- a/packages/app/src/tests/coreDataSource.test.ts
+++ b/packages/app/src/tests/coreDataSource.test.ts
@@ -1,0 +1,154 @@
+import { QueryClient } from '@tanstack/query-core'
+import { type Config, readContracts } from '@wagmi/core'
+import {
+  CoreDataSource,
+  YBOLD_STAKING_ADDRESS,
+  YBOLD_VAULT_ADDRESS,
+  YVUSD_LOCKED_ADDRESS,
+  YVUSD_UNLOCKED_ADDRESS,
+} from '@yearn-oracle-watch/sdk'
+import type { Address } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@wagmi/core', async () => {
+  const actual = await vi.importActual<typeof import('@wagmi/core')>('@wagmi/core')
+  return { ...actual, readContracts: vi.fn() }
+})
+
+const STANDARD_VAULT = '0x0000000000000000000000000000000000000001' as Address
+const DELTA = 123n
+const APR_UNIT = 10n ** 16n
+
+const success = (result: bigint) => ({ status: 'success' as const, result })
+const failure = () => ({ status: 'failure' as const, error: new Error('oracle read failed') })
+
+const createDataSource = () =>
+  new CoreDataSource({
+    queryClient: new QueryClient(),
+    wagmiConfig: {} as Config,
+    config: {
+      endpoints: {
+        kong: 'https://kong.example',
+        yDaemon: 'https://ydaemon.example',
+      },
+    },
+  })
+
+const mockedReadContracts = vi.mocked(readContracts)
+
+describe('CoreDataSource.getAprOracleData', () => {
+  beforeEach(() => {
+    mockedReadContracts.mockReset()
+  })
+
+  it('returns current and projected APRs for an ordinary vault', async () => {
+    mockedReadContracts.mockResolvedValueOnce([success(APR_UNIT), success(2n * APR_UNIT)] as never)
+
+    const result = await createDataSource().getAprOracleData(STANDARD_VAULT, 1, DELTA)
+
+    expect(result).toEqual({
+      currentApr: '1.00%',
+      projectedApr: '2.00%',
+      percentChange: '+100.00%',
+      delta: DELTA,
+    })
+    expect(mockedReadContracts).toHaveBeenCalledTimes(1)
+    expect(mockedReadContracts.mock.calls[0][1].contracts.map((contract) => contract.args)).toEqual(
+      [
+        [STANDARD_VAULT, 0n],
+        [STANDARD_VAULT, DELTA],
+      ],
+    )
+  })
+
+  it('routes yBOLD oracle calls through the staked yBOLD address', async () => {
+    mockedReadContracts.mockResolvedValueOnce([
+      success(3n * APR_UNIT),
+      success(4n * APR_UNIT),
+    ] as never)
+
+    await createDataSource().getAprOracleData(YBOLD_VAULT_ADDRESS, 1, DELTA)
+
+    expect(mockedReadContracts.mock.calls[0][1].contracts.map((contract) => contract.args)).toEqual(
+      [
+        [YBOLD_STAKING_ADDRESS, 0n],
+        [YBOLD_STAKING_ADDRESS, DELTA],
+      ],
+    )
+  })
+
+  it('groups and sums Locked yvUSD reads by delta', async () => {
+    mockedReadContracts.mockResolvedValueOnce([
+      success(APR_UNIT),
+      success(2n * APR_UNIT),
+      success(3n * APR_UNIT),
+      success(4n * APR_UNIT),
+    ] as never)
+
+    const result = await createDataSource().getAprOracleData(YVUSD_LOCKED_ADDRESS, 1, DELTA)
+
+    expect(result).toEqual({
+      currentApr: '3.00%',
+      projectedApr: '7.00%',
+      percentChange: '+133.33%',
+      delta: DELTA,
+    })
+    expect(mockedReadContracts.mock.calls[0][1].contracts.map((contract) => contract.args)).toEqual(
+      [
+        [YVUSD_UNLOCKED_ADDRESS, 0n],
+        [YVUSD_LOCKED_ADDRESS, 0n],
+        [YVUSD_UNLOCKED_ADDRESS, DELTA],
+        [YVUSD_LOCKED_ADDRESS, DELTA],
+      ],
+    )
+  })
+
+  it('remaps per-index getExpectedApr fallbacks before summing', async () => {
+    mockedReadContracts
+      .mockResolvedValueOnce([
+        success(APR_UNIT),
+        failure(),
+        failure(),
+        success(4n * APR_UNIT),
+      ] as never)
+      .mockResolvedValueOnce([success(2n * APR_UNIT), success(3n * APR_UNIT)] as never)
+
+    const result = await createDataSource().getAprOracleData(YVUSD_LOCKED_ADDRESS, 1, DELTA)
+
+    expect(result.currentApr).toBe('3.00%')
+    expect(result.projectedApr).toBe('7.00%')
+    expect(mockedReadContracts).toHaveBeenCalledTimes(2)
+    expect(mockedReadContracts.mock.calls[1][1].contracts).toMatchObject([
+      {
+        functionName: 'getExpectedApr',
+        args: [YVUSD_LOCKED_ADDRESS, 0n],
+      },
+      {
+        functionName: 'getExpectedApr',
+        args: [YVUSD_UNLOCKED_ADDRESS, DELTA],
+      },
+    ])
+  })
+
+  it('rejects an incomplete read when its fallback also fails', async () => {
+    mockedReadContracts
+      .mockResolvedValueOnce([success(APR_UNIT), failure()] as never)
+      .mockResolvedValueOnce([failure()] as never)
+
+    await expect(createDataSource().getAprOracleData(STANDARD_VAULT, 1, DELTA)).rejects.toThrow(
+      `APR oracle reads failed for ${STANDARD_VAULT} on chain 1`,
+    )
+  })
+
+  it('preserves successful zero values instead of treating them as failed reads', async () => {
+    mockedReadContracts.mockResolvedValueOnce([success(0n), success(0n)] as never)
+
+    await expect(createDataSource().getAprOracleData(STANDARD_VAULT, 1, DELTA)).resolves.toEqual({
+      currentApr: '0.00%',
+      projectedApr: '0.00%',
+      percentChange: null,
+      delta: DELTA,
+    })
+    expect(mockedReadContracts).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/tests/featuredVaults.test.ts
+++ b/packages/app/src/tests/featuredVaults.test.ts
@@ -1,0 +1,52 @@
+import {
+  YBOLD_STAKING_ADDRESS,
+  YBOLD_VAULT_ADDRESS,
+  YVUSD_LOCKED_ADDRESS,
+  YVUSD_UNLOCKED_ADDRESS,
+  getAprOracleVaultAddresses,
+  getVaultCategory,
+  getVaultDisplayName,
+  getVaultIconAddress,
+  isSelectableVaultMeta,
+  isYvUsdVault,
+  sumAprOracleValues,
+} from '@yearn-oracle-watch/sdk'
+import { describe, expect, it } from 'vitest'
+
+const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+
+describe('featured vault behavior', () => {
+  it('routes yBOLD oracle reads to staked yBOLD', () => {
+    expect(getAprOracleVaultAddresses(YBOLD_VAULT_ADDRESS, 1)).toEqual([YBOLD_STAKING_ADDRESS])
+  })
+
+  it('combines unlocked and locked yvUSD oracle reads for Locked yvUSD', () => {
+    expect(getAprOracleVaultAddresses(YVUSD_LOCKED_ADDRESS, 1)).toEqual([
+      YVUSD_UNLOCKED_ADDRESS,
+      YVUSD_LOCKED_ADDRESS,
+    ])
+    expect(sumAprOracleValues([2n, 3n])).toBe(5n)
+    expect(sumAprOracleValues([2n, undefined])).toBeUndefined()
+  })
+
+  it('normalizes unlocked yvUSD identity and icon without changing its asset', () => {
+    expect(getVaultDisplayName(1, YVUSD_UNLOCKED_ADDRESS, 'USD yVault')).toBe('yvUSD')
+    expect(getVaultIconAddress(1, YVUSD_UNLOCKED_ADDRESS, USDC_ADDRESS)).toBe(
+      YVUSD_UNLOCKED_ADDRESS,
+    )
+    expect(isYvUsdVault(1, YVUSD_UNLOCKED_ADDRESS)).toBe(true)
+    expect(isYvUsdVault(1, YVUSD_LOCKED_ADDRESS)).toBe(true)
+  })
+
+  it('classifies single-strategy vaults separately from allocator vaults', () => {
+    expect(getVaultCategory('Single Strategy')).toBe('strategy')
+    expect(getVaultCategory('Multi Strategy')).toBe('allocator')
+    expect(getVaultCategory('None')).toBe('allocator')
+  })
+
+  it('excludes hidden and retired vaults from selector data', () => {
+    expect(isSelectableVaultMeta({ isHidden: false, isRetired: false })).toBe(true)
+    expect(isSelectableVaultMeta({ isHidden: true, isRetired: false })).toBe(false)
+    expect(isSelectableVaultMeta({ isHidden: false, isRetired: true })).toBe(false)
+  })
+})

--- a/packages/app/src/tests/featuredVaults.test.ts
+++ b/packages/app/src/tests/featuredVaults.test.ts
@@ -1,3 +1,4 @@
+import { resolveRpcUrls } from '@/config/rpc'
 import {
   EXCLUDED_VAULT_CHAIN_IDS,
   YBOLD_STAKING_ADDRESS,
@@ -53,5 +54,22 @@ describe('featured vault behavior', () => {
 
   it('excludes Berachain from vault selector data', () => {
     expect(EXCLUDED_VAULT_CHAIN_IDS).toContain(80094)
+  })
+
+  it('uses a public RPC fallback when preview credentials are absent', () => {
+    expect(resolveRpcUrls(undefined, 'https://public.example', 'https://default.example')).toEqual([
+      'https://public.example',
+      'https://default.example',
+    ])
+    expect(
+      resolveRpcUrls(
+        'https://configured.example',
+        'https://public.example',
+        'https://default.example',
+      ),
+    ).toEqual(['https://configured.example', 'https://public.example', 'https://default.example'])
+    expect(resolveRpcUrls('', 'https://same.example', 'https://same.example')).toEqual([
+      'https://same.example',
+    ])
   })
 })

--- a/packages/app/src/tests/featuredVaults.test.ts
+++ b/packages/app/src/tests/featuredVaults.test.ts
@@ -1,4 +1,5 @@
 import {
+  EXCLUDED_VAULT_CHAIN_IDS,
   YBOLD_STAKING_ADDRESS,
   YBOLD_VAULT_ADDRESS,
   YVUSD_LOCKED_ADDRESS,
@@ -48,5 +49,9 @@ describe('featured vault behavior', () => {
     expect(isSelectableVaultMeta({ isHidden: false, isRetired: false })).toBe(true)
     expect(isSelectableVaultMeta({ isHidden: true, isRetired: false })).toBe(false)
     expect(isSelectableVaultMeta({ isHidden: false, isRetired: true })).toBe(false)
+  })
+
+  it('excludes Berachain from vault selector data', () => {
+    expect(EXCLUDED_VAULT_CHAIN_IDS).toContain(80094)
   })
 })

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -72,6 +72,9 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 3000,
     },
+    preview: {
+      allowedHosts: ['dev-vm.tail197cc7.ts.net'],
+    },
     build: {
       outDir: 'build',
     },

--- a/packages/sdk/src/datasources/CoreDataSource.ts
+++ b/packages/sdk/src/datasources/CoreDataSource.ts
@@ -1,14 +1,14 @@
 import { readContracts } from '@wagmi/core'
-import {
-  aprOracleAbi,
-  aprOracleAddress,
-  erc20Abi,
-  v3VaultAbi,
-} from '@yearn-oracle-watch/contracts'
+import { aprOracleAbi, aprOracleAddress, erc20Abi, v3VaultAbi } from '@yearn-oracle-watch/contracts'
 import _ from 'lodash'
 import { KongDataSource } from 'src/datasources/KongDataSource'
 import { YDaemonDataSource } from 'src/datasources/YDaemonDataSource'
 import { calculatePercentChange, formatApr } from 'src/utils/apr'
+import {
+  getAprOracleVaultAddresses,
+  getVaultIconAddress,
+  sumAprOracleValues,
+} from 'src/utils/featuredVaults'
 import { Address, getAddress } from 'viem'
 import { SdkContext } from '../types'
 
@@ -16,10 +16,8 @@ import { SdkContext } from '../types'
 const isDevelopment = (() => {
   try {
     return (
-      (typeof process !== 'undefined' &&
-        process.env?.NODE_ENV === 'development') ||
-      (typeof window !== 'undefined' &&
-        window.location?.hostname === 'localhost')
+      (typeof process !== 'undefined' && process.env?.NODE_ENV === 'development') ||
+      (typeof window !== 'undefined' && window.location?.hostname === 'localhost')
     )
   } catch {
     return false
@@ -53,33 +51,23 @@ export class CoreDataSource {
     this.yDaemon.dispose()
   }
 
-  async getAprOracleData(
-    vaultAddress: Address,
-    chainId: number,
-    delta: bigint
-  ) {
+  async getAprOracleData(vaultAddress: Address, chainId: number, delta: bigint) {
     devLog('🔍 getAprOracleData called with:', {
       vaultAddress,
       chainId,
       delta: delta.toString(),
     })
 
-    const expectedAprContracts = [
-      {
+    const oracleVaultAddresses = getAprOracleVaultAddresses(vaultAddress, chainId)
+    const expectedAprContracts = [0n, delta].flatMap((queryDelta) =>
+      oracleVaultAddresses.map((oracleVaultAddress) => ({
         address: aprOracleAddress[chainId as keyof typeof aprOracleAddress],
         abi: aprOracleAbi,
         functionName: 'getStrategyApr' as const,
-        args: [vaultAddress, 0n] as const,
+        args: [oracleVaultAddress, queryDelta] as const,
         chainId,
-      },
-      {
-        address: aprOracleAddress[chainId as keyof typeof aprOracleAddress],
-        abi: aprOracleAbi,
-        functionName: 'getStrategyApr' as const,
-        args: [vaultAddress, delta] as const,
-        chainId,
-      },
-    ]
+      })),
+    )
 
     devLog('📋 Contract calls prepared:', {
       oracleAddress: aprOracleAddress[chainId as keyof typeof aprOracleAddress],
@@ -87,7 +75,7 @@ export class CoreDataSource {
       contracts: expectedAprContracts.map((c) => ({
         functionName: c.functionName,
         args: c.args.map((arg: Address | bigint) =>
-          typeof arg === 'bigint' ? arg.toString() : arg
+          typeof arg === 'bigint' ? arg.toString() : arg,
         ),
       })),
     })
@@ -103,7 +91,7 @@ export class CoreDataSource {
         status: result.status,
         result: result.result ? (result.result as bigint).toString() : null,
         error: result.error,
-      }))
+      })),
     )
 
     // Check for failed calls and create fallback contracts
@@ -115,9 +103,7 @@ export class CoreDataSource {
     const finalResults = [...expectedAprResults]
 
     if (failedIndices.length > 0) {
-      devLog(
-        `🔄 Found ${failedIndices.length} failed calls, attempting fallback to getExpectedApr`
-      )
+      devLog(`🔄 Found ${failedIndices.length} failed calls, attempting fallback to getExpectedApr`)
 
       const fallbackContracts = failedIndices.map((index) => ({
         address: aprOracleAddress[chainId as keyof typeof aprOracleAddress],
@@ -128,13 +114,12 @@ export class CoreDataSource {
       }))
 
       devLog('📋 Fallback contract calls prepared:', {
-        oracleAddress:
-          aprOracleAddress[chainId as keyof typeof aprOracleAddress],
+        oracleAddress: aprOracleAddress[chainId as keyof typeof aprOracleAddress],
         contractsCount: fallbackContracts.length,
         contracts: fallbackContracts.map((c) => ({
           functionName: c.functionName,
           args: c.args.map((arg: Address | bigint) =>
-            typeof arg === 'bigint' ? arg.toString() : arg
+            typeof arg === 'bigint' ? arg.toString() : arg,
           ),
         })),
       })
@@ -150,37 +135,39 @@ export class CoreDataSource {
           status: result.status,
           result: result.result ? (result.result as bigint).toString() : null,
           error: result.error,
-        }))
+        })),
       )
 
       // Replace failed results with fallback results
       failedIndices.forEach((originalIndex, fallbackIndex) => {
         if (fallbackResults[fallbackIndex].status === 'success') {
           finalResults[originalIndex] = fallbackResults[fallbackIndex]
-          devLog(
-            `✅ Successfully recovered index ${originalIndex} using getExpectedApr fallback`
-          )
+          devLog(`✅ Successfully recovered index ${originalIndex} using getExpectedApr fallback`)
         } else {
           devLog(`❌ Fallback also failed for index ${originalIndex}`)
         }
       })
     }
 
-    const [currentApr, projectedApr] = _.chain(finalResults)
-      .map((v) => v.result as bigint)
-      .value() as [bigint, bigint]
+    const valuesPerDelta = oracleVaultAddresses.length
+    const sumAprResults = (offset: number): bigint | undefined => {
+      const results = finalResults.slice(offset, offset + valuesPerDelta)
+      return sumAprOracleValues(
+        results.map((result) =>
+          result.status === 'success' ? (result.result as bigint) : undefined,
+        ),
+      )
+    }
+    const currentApr = sumAprResults(0)
+    const projectedApr = sumAprResults(valuesPerDelta)
 
     devLog('🔢 Extracted APR values:', {
       currentApr: currentApr ? currentApr.toString() : null,
       projectedApr: projectedApr ? projectedApr.toString() : null,
     })
 
-    const currentAprFormatted = currentApr
-      ? formatApr(currentApr)
-      : formatApr(0n)
-    const projectedAprFormatted = projectedApr
-      ? formatApr(projectedApr)
-      : formatApr(0n)
+    const currentAprFormatted = currentApr ? formatApr(currentApr) : formatApr(0n)
+    const projectedAprFormatted = projectedApr ? formatApr(projectedApr) : formatApr(0n)
 
     devLog('✨ Formatted APR values:', {
       currentAprFormatted,
@@ -188,10 +175,7 @@ export class CoreDataSource {
     })
 
     // Calculate percent change between current and projected APR
-    const percentChange = calculatePercentChange(
-      currentAprFormatted,
-      projectedAprFormatted
-    )
+    const percentChange = calculatePercentChange(currentAprFormatted, projectedAprFormatted)
 
     devLog('📈 Calculated percent change:', percentChange)
 
@@ -216,13 +200,15 @@ export class CoreDataSource {
    */
   async discoverVaultsFromContract(
     vaultAddress: Address,
-    chainIds: number[] = []
+    chainIds: number[] = [],
   ): Promise<
     Array<{
       address: Address
       symbol: string
       name: string
       chainId: number
+      category: 'allocator'
+      iconAddress: Address
       asset: {
         address: Address
         name: string
@@ -238,6 +224,8 @@ export class CoreDataSource {
       symbol: string
       name: string
       chainId: number
+      category: 'allocator'
+      iconAddress: Address
       asset: {
         address: Address
         name: string
@@ -337,6 +325,8 @@ export class CoreDataSource {
           symbol: vaultSymbol,
           name: vaultName,
           chainId,
+          category: 'allocator',
+          iconAddress: getVaultIconAddress(chainId, checksumVault, assetAddr),
           asset: {
             address: assetAddr,
             name: assetName,

--- a/packages/sdk/src/datasources/CoreDataSource.ts
+++ b/packages/sdk/src/datasources/CoreDataSource.ts
@@ -161,13 +161,17 @@ export class CoreDataSource {
     const currentApr = sumAprResults(0)
     const projectedApr = sumAprResults(valuesPerDelta)
 
+    if (currentApr === undefined || projectedApr === undefined) {
+      throw new Error(`APR oracle reads failed for ${vaultAddress} on chain ${chainId}`)
+    }
+
     devLog('🔢 Extracted APR values:', {
-      currentApr: currentApr ? currentApr.toString() : null,
-      projectedApr: projectedApr ? projectedApr.toString() : null,
+      currentApr: currentApr.toString(),
+      projectedApr: projectedApr.toString(),
     })
 
-    const currentAprFormatted = currentApr ? formatApr(currentApr) : formatApr(0n)
-    const projectedAprFormatted = projectedApr ? formatApr(projectedApr) : formatApr(0n)
+    const currentAprFormatted = formatApr(currentApr)
+    const projectedAprFormatted = formatApr(projectedApr)
 
     devLog('✨ Formatted APR values:', {
       currentAprFormatted,

--- a/packages/sdk/src/datasources/KongDataSource.ts
+++ b/packages/sdk/src/datasources/KongDataSource.ts
@@ -14,13 +14,18 @@ import { Address } from 'viem'
 import { createCachedSdk } from '../graphql/cache'
 import type { CachedSdk } from '../graphql/types'
 import { getSdk as kong_getSdk } from '../queries/kong/generated'
+import { getVaultDisplayName, getVaultIconAddress } from '../utils/featuredVaults'
 import { BaseDataSource } from './BaseDataSource'
+
+export type VaultCategory = 'allocator' | 'strategy'
 
 export type NonNullableVaultData = {
   address: Address
   symbol: string
   name: string
   chainId: number
+  category: VaultCategory
+  iconAddress: Address
   asset: {
     decimals: number
     address: Address
@@ -28,6 +33,13 @@ export type NonNullableVaultData = {
     symbol: string
   }
 }
+
+export const getVaultCategory = (kind?: string | null): VaultCategory =>
+  kind?.toLowerCase().includes('single') ? 'strategy' : 'allocator'
+
+export const isSelectableVaultMeta = (
+  meta?: { isHidden?: boolean | null; isRetired?: boolean | null } | null,
+): boolean => !meta?.isHidden && !meta?.isRetired
 
 export class KongDataSource extends BaseDataSource {
   private gql!: CachedSdk<typeof kong_getSdk>
@@ -49,19 +61,27 @@ export class KongDataSource extends BaseDataSource {
     const data = await this.gql.GetVaultData()
     const vaults = (data.vaults || [])
       .filter((vault): vault is NonNullable<typeof vault> => vault !== null)
-      .filter((vault) => !vault.meta?.isHidden)
-      .map((vault) => ({
-        address: (vault.address || '') as Address,
-        symbol: vault.symbol || '',
-        name: vault.name || '',
-        chainId: vault.chainId || 0,
-        asset: {
-          decimals: vault.asset?.decimals || 0,
-          address: (vault.asset?.address || '') as Address,
-          name: vault.asset?.name || '',
-          symbol: vault.asset?.symbol || '',
-        },
-      }))
+      .filter((vault) => isSelectableVaultMeta(vault.meta))
+      .map((vault) => {
+        const address = (vault.address || '') as Address
+        const chainId = vault.chainId || 0
+        const assetAddress = (vault.asset?.address || '') as Address
+
+        return {
+          address,
+          symbol: vault.symbol || '',
+          name: getVaultDisplayName(chainId, address, vault.name || ''),
+          chainId,
+          category: getVaultCategory(vault.meta?.kind),
+          iconAddress: getVaultIconAddress(chainId, address, assetAddress),
+          asset: {
+            decimals: vault.asset?.decimals || 0,
+            address: assetAddress,
+            name: vault.asset?.name || '',
+            symbol: vault.asset?.symbol || '',
+          },
+        }
+      })
     return filterVaultsByChainIds(vaults, [250])
   }
 }

--- a/packages/sdk/src/datasources/KongDataSource.ts
+++ b/packages/sdk/src/datasources/KongDataSource.ts
@@ -18,6 +18,7 @@ import { getVaultDisplayName, getVaultIconAddress } from '../utils/featuredVault
 import { BaseDataSource } from './BaseDataSource'
 
 export type VaultCategory = 'allocator' | 'strategy'
+export const EXCLUDED_VAULT_CHAIN_IDS = [250, 80094] as const
 
 export type NonNullableVaultData = {
   address: Address
@@ -82,6 +83,6 @@ export class KongDataSource extends BaseDataSource {
           },
         }
       })
-    return filterVaultsByChainIds(vaults, [250])
+    return filterVaultsByChainIds(vaults, [...EXCLUDED_VAULT_CHAIN_IDS])
   }
 }

--- a/packages/sdk/src/datasources/index.ts
+++ b/packages/sdk/src/datasources/index.ts
@@ -1,3 +1,4 @@
 export * from './BaseDataSource'
 export * from './CoreDataSource'
+export * from './KongDataSource'
 export * from './YDaemonDataSource'

--- a/packages/sdk/src/queries/kong/generated.ts
+++ b/packages/sdk/src/queries/kong/generated.ts
@@ -932,7 +932,7 @@ export type kong_VestingEscrowCreatedLog = {
 export type kong_GetVaultDataQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type kong_GetVaultDataQuery = { vaults?: Array<{ address?: string | null, symbol?: string | null, name?: string | null, chainId?: number | null, meta?: { isHidden?: boolean | null } | null, asset?: { decimals?: number | null, address?: string | null, name?: string | null, symbol?: string | null } | null } | null> | null };
+export type kong_GetVaultDataQuery = { vaults?: Array<{ address?: string | null, symbol?: string | null, name?: string | null, chainId?: number | null, meta?: { isHidden?: boolean | null, isRetired?: boolean | null, kind?: string | null } | null, asset?: { decimals?: number | null, address?: string | null, name?: string | null, symbol?: string | null } | null } | null> | null };
 
 
 export const GetVaultDataDocument = /*#__PURE__*/ gql`
@@ -944,6 +944,8 @@ export const GetVaultDataDocument = /*#__PURE__*/ gql`
     chainId
     meta {
       isHidden
+      isRetired
+      kind
     }
     asset {
       decimals

--- a/packages/sdk/src/queries/kong/query.graphql
+++ b/packages/sdk/src/queries/kong/query.graphql
@@ -6,6 +6,8 @@ query GetVaultData {
     chainId
     meta {
       isHidden
+      isRetired
+      kind
     }
     asset {
       decimals

--- a/packages/sdk/src/utils/featuredVaults.ts
+++ b/packages/sdk/src/utils/featuredVaults.ts
@@ -1,0 +1,53 @@
+import type { Address } from 'viem'
+
+export const YBOLD_VAULT_ADDRESS = '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8' as Address
+export const YBOLD_STAKING_ADDRESS = '0x23346B04a7f55b8760E5860AA5A77383D63491cD' as Address
+export const YVUSD_UNLOCKED_ADDRESS = '0x696d02Db93291651ED510704c9b286841d506987' as Address
+export const YVUSD_LOCKED_ADDRESS = '0xAaaFEa48472f77563961Cdb53291DEDfB46F9040' as Address
+
+const MAINNET_CHAIN_ID = 1
+const toAddressKey = (address?: string) => address?.toLowerCase()
+
+export const isYvUsdVault = (chainId: number, address?: string): boolean =>
+  chainId === MAINNET_CHAIN_ID &&
+  [YVUSD_UNLOCKED_ADDRESS, YVUSD_LOCKED_ADDRESS].some(
+    (candidate) => toAddressKey(candidate) === toAddressKey(address),
+  )
+
+export const getAprOracleVaultAddresses = (vaultAddress: Address, chainId: number): Address[] => {
+  if (chainId !== MAINNET_CHAIN_ID) return [vaultAddress]
+
+  const addressKey = toAddressKey(vaultAddress)
+  if (addressKey === toAddressKey(YBOLD_VAULT_ADDRESS)) {
+    return [YBOLD_STAKING_ADDRESS]
+  }
+  if (addressKey === toAddressKey(YVUSD_LOCKED_ADDRESS)) {
+    return [YVUSD_UNLOCKED_ADDRESS, YVUSD_LOCKED_ADDRESS]
+  }
+
+  return [vaultAddress]
+}
+
+export const sumAprOracleValues = (values: Array<bigint | undefined>): bigint | undefined =>
+  values.every((value): value is bigint => value !== undefined)
+    ? values.reduce((sum, value) => sum + value, 0n)
+    : undefined
+
+export const getVaultDisplayName = (
+  chainId: number,
+  address: string,
+  fallbackName: string,
+): string =>
+  chainId === MAINNET_CHAIN_ID && toAddressKey(address) === toAddressKey(YVUSD_UNLOCKED_ADDRESS)
+    ? 'yvUSD'
+    : fallbackName
+
+export const getVaultIconAddress = (
+  chainId: number,
+  vaultAddress: Address,
+  assetAddress: Address,
+): Address =>
+  chainId === MAINNET_CHAIN_ID &&
+  toAddressKey(vaultAddress) === toAddressKey(YVUSD_UNLOCKED_ADDRESS)
+    ? YVUSD_UNLOCKED_ADDRESS
+    : assetAddress

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -141,3 +141,4 @@ export const scale = (bal?: bigint, val?: number, decimals?: number) =>
   ((bal || 0n) * simpleToExact(val || 0)) / BigInt(10 ** (decimals || 18))
 
 export * from './apr'
+export * from './featuredVaults'


### PR DESCRIPTION
### Summary
Improve APR display and vault selection for featured Yearn vaults. The app now handles yvUSD, Locked yvUSD, and yBOLD correctly, removes retired and Berachain vaults, and avoids showing failed RPC reads as zero APR.

### How to review
1. Review `packages/sdk/src/utils/featuredVaults.ts` and `CoreDataSource.ts` for the featured-vault oracle routing and Locked yvUSD aggregation.
2. Review `KongDataSource.ts` and `VaultQueryCard.tsx` for retired-vault filtering and the Allocator Vaults / Tokenized Strategies tabs.
3. Review `packages/app/src/config/wagmi.ts` and `rpc.ts` for the ordered RPC fallback behavior.
4. The generated Kong client only reflects the added `meta.kind` and `meta.isRetired` query fields.

### Test plan
- [x] Manual: Confirm yvUSD and Locked yvUSD show `N/A` for projected APY with the warning tooltip.
- [x] Manual: Confirm USDC-1 and DAI-1 show nonzero current APY values when preview RPC credentials are absent.
- [x] Manual: Confirm the selector shows Allocator Vaults and Tokenized Strategies tabs and does not show Berachain.
- [x] Automated: `bunx vitest run src/tests/coreDataSource.test.ts src/tests/featuredVaults.test.ts --reporter=verbose` (13 tests passed).
- [x] Automated: SDK and application production builds passed.
- [ ] Type check: Existing unrelated errors remain in `TokenPricesTest.tsx` and `VaultPositionCard.tsx`.

### Risk / impact
This changes read-only APR display and vault discovery. It does not submit transactions or move funds. Featured-vault address routing and public RPC fallbacks can affect which APR values are displayed and whether a read succeeds. Reverting this PR restores the previous oracle and selector behavior.
